### PR TITLE
Text/btm-padding: Fixed spacing when screen width is small

### DIFF
--- a/src/components/RouteStatistics.tsx
+++ b/src/components/RouteStatistics.tsx
@@ -27,7 +27,7 @@ const RouteStatistics: VoidComponent<RouteStatisticsProps> = (props) => {
   const [timeline] = createResource(() => props.route, getTimelineStatistics)
 
   return (
-    <div class={clsx('flex h-10 w-full items-stretch gap-8', props.class)}>
+    <div class={clsx('flex h-full w-full items-stretch gap-8', props.class)}>
       <div class="flex flex-col justify-between">
         <Typography variant="body-sm" color="on-surface-variant">
           Distance


### PR DESCRIPTION
The bottom spacing would be very tight when on a small width device.

## Old
<img width="415" alt="bottom-spacing-tight" src="https://github.com/commaai/new-connect/assets/142481257/9268198c-f7b1-418b-8acd-456399cfd9f0">

## New
<img width="440" alt="new" src="https://github.com/commaai/new-connect/assets/142481257/a85ecb68-f081-4a4c-b35f-8126b9d94fad">


## Compare vid with change

https://github.com/commaai/new-connect/assets/142481257/63afe286-c64e-4f8d-b7c5-7a66716aead2


