### PR TITLE
IconButton: add padding and update dashboard drawer close icon

### DIFF
--- a/src/components/material/IconButton.tsx
+++ b/src/components/material/IconButton.tsx
@@ -24,7 +24,7 @@ const IconButton: Component<IconButtonProps> = (props) => {
   return (
     <ButtonBase
       class={clsx(
-        'state-layer inline-flex items-center justify-center rounded-full before:rounded-full before:bg-on-surface',
+        'state-layer inline-flex items-center justify-center rounded-full before:rounded-full before:bg-on-surface p-2',
         buttonSize,
         props.class,
       )}

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -40,7 +40,7 @@ const DashboardDrawer = (props: {
     <>
       <TopAppBar
         as="h1"
-        leading={<IconButton onClick={props.onClose}>menu</IconButton>}
+        leading={<IconButton onClick={props.onClose}>arrow_back</IconButton>}
       >
         comma connect
       </TopAppBar>


### PR DESCRIPTION
### Old Icon
![old-icon](https://github.com/commaai/new-connect/assets/142481257/6f2736e9-f430-4a2c-9dba-e009d4bee52d)

### New Icon
![new-icon](https://github.com/commaai/new-connect/assets/142481257/48ad80c3-d4b5-4b1c-ab71-72e07ea13ef5)

---
### Old icon button padding
<img width="404" alt="old-spacing" src="https://github.com/commaai/new-connect/assets/142481257/d1455113-8ca5-4b64-8c4f-a9e4318912c9">

### New icon button padding
<img width="414" alt="new-spacing" src="https://github.com/commaai/new-connect/assets/142481257/e44cc6c5-893d-48ae-a728-d828d1addf98">

---
### Changes made
- **New icon:** onClose button should not be a `menu` icon which suggests another menu flow. It should be a back arrow which suggests the drawer to close and to return back to where you came from.
- **Added .5rem padding**: Current buttons did not have any padding so when mouse hoovered or on press the icon would show the alternative state with little padding shown above.