### PR TITLE
Fixed overflow when scrolling up

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -119,7 +119,7 @@
      * fill visible viewport
      * https://developers.google.com/web/updates/2016/12/url-bar-resizing
      */
-    @apply h-full;
+    @apply h-full overflow-hidden;
   }
 
   button {


### PR DESCRIPTION
### Sidebar showing if scrolled up too much
<img width="361" alt="ui-overflow" src="https://github.com/commaai/new-connect/assets/142481257/39a625b3-0c4a-42c5-a566-de4c42da3037">

This shows up for both mobile and desktop.

### First one shows the overflow second shows it fixed

https://github.com/commaai/new-connect/assets/142481257/801b3ad6-ea1a-444c-8a8c-52c6bbde3c45






