### PR TITLE
TopAppBar: fix flashing "Device" text in Dashboard

### DIFF
--- a/src/pages/dashboard/activities/DeviceActivity.tsx
+++ b/src/pages/dashboard/activities/DeviceActivity.tsx
@@ -21,7 +21,7 @@ const DeviceActivity: VoidComponent<DeviceActivityProps> = (props) => {
   return (
     <>
       <TopAppBar leading={<IconButton onClick={toggleDrawer}>menu</IconButton>}>
-        <Suspense fallback={<>Device</>}>{device()?.alias}</Suspense>
+        <Suspense fallback={<></>}>{device()?.alias}</Suspense>
       </TopAppBar>
       <div class="flex flex-col gap-4 px-4 pb-4">
         <div class="h-[72px] overflow-hidden rounded-lg bg-surface-container-low">


### PR DESCRIPTION
**Problem:**
Whenever visiting `RouteActivity` page then clicking the back button to go back to `Dashboard` you will see the text "Device" show then disappear. The flashing text is located in the top left next to menu button.

**Solution:**
Change the fallback text to an empty fragment because flashing the text "Device" doesn't provide any useful information to users. I thought about changing the fallback text to "loading..." but didn't think having a loading text was necessary since all we are waiting for is a device name, or waiting for nothing if user doesn't have an alias for their comma device.
<br>


### "Device" flickering if you did NOT name device

https://github.com/commaai/new-connect/assets/142481257/77ba4387-040c-4f2d-baa7-83257a84a91f

<br>

### "Device" flickering if you named your device aka `alias`

https://github.com/commaai/new-connect/assets/142481257/9d60190b-69b0-403a-82d0-f1f3e9e1d393

<br>

### FIXED: No device alias

https://github.com/commaai/new-connect/assets/142481257/d8309b05-d45d-4a37-996e-8aae32c24ab5

<br>

### FIXED: With device alias

https://github.com/commaai/new-connect/assets/142481257/4e566847-1488-44e2-86e2-bdb960be4216





