### PR TITLE
CI(Preview): add retries to find PR script

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -30,18 +30,29 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const response = await github.rest.search.issuesAndPullRequests({
-              q: 'repo:${{ github.repository }} is:pr sha:${{ github.event.workflow_run.head_sha }}',
-              per_page: 1,
-            })
-            const items = response.data.items
-            if (items.length < 1) {
-              console.error('No PRs found')
-              return
+            async function findPR() {
+              for (let retries = 3; retries > 0; retries--) {
+                try {
+                  const response = await github.rest.search.issuesAndPullRequests({
+                    q: 'repo:${{ github.repository }} is:pr sha:${{ github.event.workflow_run.head_sha }}',
+                    per_page: 1,
+                  });
+                  const items = response.data.items;
+                  if (items.length < 1) {
+                    throw new Error('No PRs found');
+                  }
+                  const pullRequestNumber = items[0].number
+                  console.info("Pull request number is", pullRequestNumber);
+                  return pullRequestNumber
+                } catch (error) {
+                  console.error(`Retrying... (${3 - retries + 1}/3)`);
+                  if (retries === 1) throw error;
+                  await new Promise(res => setTimeout(res, 10000));
+                }
+              }
             }
-            const pullRequestNumber = items[0].number
-            console.info("Pull request number is", pullRequestNumber)
-            return pullRequestNumber
+            return findPR();
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # deploy
       - name: Deploy to Cloudflare Pages

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -29,30 +29,20 @@ jobs:
         id: pr
         uses: actions/github-script@v7
         with:
+          retries: 3
           script: |
-            async function findPR() {
-              for (let retries = 3; retries > 0; retries--) {
-                try {
-                  const response = await github.rest.search.issuesAndPullRequests({
-                    q: 'repo:${{ github.repository }} is:pr sha:${{ github.event.workflow_run.head_sha }}',
-                    per_page: 1,
-                  });
-                  const items = response.data.items;
-                  if (items.length < 1) {
-                    throw new Error('No PRs found');
-                  }
-                  const pullRequestNumber = items[0].number
-                  console.info("Pull request number is", pullRequestNumber);
-                  return pullRequestNumber
-                } catch (error) {
-                  console.error(`Retrying... (${3 - retries + 1}/3)`);
-                  if (retries === 1) throw error;
-                  await new Promise(res => setTimeout(res, 10000));
-                }
-              }
+            const response = await github.rest.search.issuesAndPullRequests({
+              q: 'repo:${{ github.repository }} is:pr sha:${{ github.event.workflow_run.head_sha }}',
+              per_page: 1,
+            })
+            const items = response.data.items
+            if (items.length < 1) {
+              console.error('No PRs found')
+              return
             }
-            return findPR();
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+            const pullRequestNumber = items[0].number
+            console.info('Pull request number is', pullRequestNumber)
+            return pullRequestNumber
 
       # deploy
       - name: Deploy to Cloudflare Pages


### PR DESCRIPTION
To my understanding this is so pose to help by increasing the rate limit since I added the Github Token. I also added a retry mechanism instead of trying to rerun actions manually. I noticed that Cameron also ran into the secondary rate limit so hopefully this would help us not hit that limit anymore.

I'm not entirely confident this would help so feel free to close this. My previous PRs are now able to generate the Preview Link.

Reference Link: [docs.github.com](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#about-secondary-rate-limits)