### PR TITLE
Preview speedup - use chromium not webkit

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -14,7 +14,7 @@ jobs:
   preview:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 2  # FIXME: this should be 1m!
+    timeout-minutes: 1
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
@@ -64,7 +64,7 @@ jobs:
       - name: take screenshots
         run: |
           bun install --frozen-lockfile
-          bun playwright install --with-deps webkit
+          bun playwright install chromium
           node src/ci/screenshots.cjs https://${{ steps.pr.outputs.result }}.connect-d5y.pages.dev ${{ github.workspace }}/ci-artifacts
 
       - name: Push Screenshots

--- a/src/ci/screenshots.cjs
+++ b/src/ci/screenshots.cjs
@@ -1,5 +1,5 @@
 /* eslint-disable */
-const { webkit, devices } = require('playwright');
+const { chromium, devices } = require('playwright');
 
 const base_url = process.argv[2];
 const out_dir = process.argv[3] ? process.argv[3] : 'screenshots';
@@ -23,13 +23,13 @@ async function takeScreenshots(deviceType, context) {
 }
 
 (async () => {
-  const mobile_browser = await webkit.launch()
+  const mobile_browser = await chromium.launch()
   const iphone_13 = devices['iPhone 13']
   const mobile_context = await mobile_browser.newContext(iphone_13)
   await takeScreenshots('mobile', mobile_context)
   await mobile_browser.close()
 
-  const desktop_browser = await webkit.launch()
+  const desktop_browser = await chromium.launch()
   const desktop_context = await desktop_browser.newContext({viewport: { width: 1920, height: 1080 }})
   await takeScreenshots('desktop', desktop_context)
   await desktop_browser.close()


### PR DESCRIPTION
Chromium's deps are present in the runner base image so much faster than using webkit. 

Speed up is 53s -> 27s https://github.com/signed-long/new-connect/actions/runs/9786617432/job/27021805208