### PR TITLE
Dashboard: default to last selected device

### DIFF
--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -79,7 +79,7 @@ const DashboardLayout: Component<RouteSectionProps> = () => {
 
     const lastSelectedDongleId = storage.getItem('lastSelectedDongleId')
     if (devices()?.some((device) => device.dongle_id === lastSelectedDongleId)) return lastSelectedDongleId
-    return devices()?.[0].dongle_id
+    return devices()?.[0]?.dongle_id
   }
 
   return (

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -82,13 +82,11 @@ const DashboardLayout: Component<RouteSectionProps> = () => {
       >
         <Switch
           fallback={
-            <>
-              <TopAppBar
-                leading={<IconButton onClick={toggleDrawer}>menu</IconButton>}
-              >
-                No device
-              </TopAppBar>
-            </>
+            <TopAppBar
+              leading={<IconButton onClick={toggleDrawer}>menu</IconButton>}
+            >
+              No device
+            </TopAppBar>
           }
         >
           <Match when={!!profile.error}>

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -8,8 +8,8 @@ import {
   Show,
   Switch,
 } from 'solid-js'
-import type { VoidComponent } from 'solid-js'
-import { Navigate, useLocation } from '@solidjs/router'
+import type { Component } from 'solid-js'
+import { Navigate, type RouteSectionProps, useLocation } from '@solidjs/router'
 
 import { getDevices } from '~/api/devices'
 import { getProfile } from '~/api/profile'
@@ -57,7 +57,7 @@ const DashboardDrawer = (props: {
   )
 }
 
-const DashboardLayout: VoidComponent = () => {
+const DashboardLayout: Component<RouteSectionProps> = () => {
   const location = useLocation()
 
   const pathParts = () => location.pathname.split('/').slice(1).filter(Boolean)

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -23,6 +23,7 @@ import TopAppBar from '~/components/material/TopAppBar'
 import DeviceList from './components/DeviceList'
 import DeviceActivity from './activities/DeviceActivity'
 import RouteActivity from './activities/RouteActivity'
+import storage from '~/utils/storage'
 
 type DashboardState = {
   drawer: Accessor<boolean>
@@ -72,6 +73,15 @@ const DashboardLayout: Component<RouteSectionProps> = () => {
   const [devices] = createResource(getDevices)
   const [profile] = createResource(getProfile)
 
+  const getDefaultDongleId = () => {
+    // Do not redirect if dongle ID already selected
+    if (dongleId()) return undefined
+
+    const lastSelectedDongleId = storage.getItem('lastSelectedDongleId')
+    if (devices()?.some((device) => device.dongle_id === lastSelectedDongleId)) return lastSelectedDongleId
+    return devices()?.[0].dongle_id
+  }
+
   return (
     <DashboardContext.Provider value={{ drawer, setDrawer, toggleDrawer }}>
       <Drawer
@@ -98,8 +108,9 @@ const DashboardLayout: Component<RouteSectionProps> = () => {
           <Match when={dongleId()} keyed>
             <DeviceActivity dongleId={dongleId()} />
           </Match>
-          <Match when={devices()?.length} keyed>
-            <Navigate href={`/${devices()![0].dongle_id}`} />
+          <Match when={getDefaultDongleId()} keyed>{(defaultDongleId) => (
+            <Navigate href={`/${defaultDongleId}`} />
+          )}
           </Match>
         </Switch>
       </Drawer>

--- a/src/pages/dashboard/components/DeviceList.tsx
+++ b/src/pages/dashboard/components/DeviceList.tsx
@@ -7,6 +7,7 @@ import Icon from '~/components/material/Icon'
 import List, { ListItem, ListItemContent } from '~/components/material/List'
 import type { Device } from '~/types'
 import { getDeviceName } from '~/utils/device'
+import storage from '~/utils/storage'
 
 import { DashboardContext } from '../Dashboard'
 
@@ -24,7 +25,10 @@ const DeviceList: VoidComponent<DeviceListProps> = (props) => {
       <For each={props.devices}>
         {(device) => {
           const isSelected = () => location.pathname.includes(device.dongle_id)
-          const onClick = () => setDrawer(false)
+          const onClick = () => {
+            setDrawer(false)
+            storage.setItem('lastSelectedDongleId', device.dongle_id)
+          }
           return (
             <ListItem
               variant="nav"

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,21 @@
+const STORAGE_PREFIX = 'connect:'
+
+type StorageKey = 'lastSelectedDongleId'
+
+export default {
+  getItem(key: StorageKey): string | null {
+    return localStorage.getItem(STORAGE_PREFIX + key)
+  },
+
+  removeItem(key: StorageKey): void {
+    localStorage.removeItem(STORAGE_PREFIX + key)
+  },
+
+  setItem(key: StorageKey, value: string | null): void {
+    if (value === null) {
+      this.removeItem(key)
+    } else {
+      localStorage.setItem(STORAGE_PREFIX + key, value)
+    }
+  },
+}

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -13,15 +13,7 @@ export default {
     return localStorage.getItem(STORAGE_PREFIX + key)
   },
 
-  removeItem(key: StorageKey): void {
-    localStorage.removeItem(STORAGE_PREFIX + key)
-  },
-
-  setItem(key: StorageKey, value: string | null): void {
-    if (value === null) {
-      this.removeItem(key)
-    } else {
-      localStorage.setItem(STORAGE_PREFIX + key, value)
-    }
+  setItem(key: StorageKey, value: string): void {
+    localStorage.setItem(STORAGE_PREFIX + key, value)
   },
 }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,5 +1,11 @@
+/**
+ * Prefix to prevent conflicts with other apps writing to local storage in development.
+ */
 const STORAGE_PREFIX = 'connect:'
 
+/**
+ * Storage key type. Used to catch typos in the key name.
+ */
 type StorageKey = 'lastSelectedDongleId'
 
 export default {


### PR DESCRIPTION
Write the dongle ID to local storage when a device is selected, and use that as the default when loading the app (unless a dongle is already set in the URL)

closes #45 