### PR TITLE
Deprecate use of RouteSegments segment times fields

### DIFF
--- a/src/components/RouteCard.tsx
+++ b/src/components/RouteCard.tsx
@@ -10,8 +10,8 @@ import RouteStatistics from '~/components/RouteStatistics'
 import type { RouteSegments } from '~/types'
 
 const RouteHeader = (props: { route: RouteSegments }) => {
-  const startTime = () => dayjs(props.route.segment_start_times[0])
-  const endTime = () => dayjs(props.route.segment_end_times.at(-1))
+  const startTime = () => dayjs(props.route.start_time_utc_millis)
+  const endTime = () => dayjs(props.route.end_time_utc_millis)
 
   const headline = () => startTime().format('ddd, MMM D, YYYY')
   const subhead = () => `${startTime().format('h:mm A')} to ${endTime().format('h:mm A')}`

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -29,7 +29,7 @@ const RouteList: VoidComponent<RouteListProps> = (props) => {
   const getKey = (previousPageData?: RouteSegments[]): string | undefined => {
     if (!previousPageData) return endpoint()
     if (previousPageData.length === 0) return undefined
-    const lastSegmentEndTime = previousPageData.at(-1)!.segment_start_times.at(-1)!
+    const lastSegmentEndTime = previousPageData.at(-1)!.segment_end_times.at(-1)!
     return `${endpoint()}&end=${lastSegmentEndTime - 1}`
   }
   const getPage = (page: number): Promise<RouteSegments[]> => {

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -29,7 +29,7 @@ const RouteList: VoidComponent<RouteListProps> = (props) => {
   const getKey = (previousPageData?: RouteSegments[]): string | undefined => {
     if (!previousPageData) return endpoint()
     if (previousPageData.length === 0) return undefined
-    const lastSegmentEndTime = previousPageData.at(-1)!.segment_end_times.at(-1)!
+    const lastSegmentEndTime = previousPageData.at(-1)!.end_time_utc_millis
     return `${endpoint()}&end=${lastSegmentEndTime - 1}`
   }
   const getPage = (page: number): Promise<RouteSegments[]> => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -90,9 +90,6 @@ export interface RouteShareSignature extends Record<string, string> {
 export interface RouteSegments extends Route {
   end_time_utc_millis: number
   is_preserved: boolean
-  segment_end_times: number[]
-  segment_numbers: number[]
-  segment_start_times: number[]
   share_exp: RouteShareSignature['exp']
   share_sig: RouteShareSignature['sig']
   start_time_utc_millis: number


### PR DESCRIPTION
Closes #53 

These change deprecate use of `segment_start_times`, `segment_end_times` and `segment_numbers` in preparation for removing these fields from the network payload.