### PR TITLE
CI: add `secrets: inherit` to preview workflow call

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,5 +55,6 @@ jobs:
     needs: build
     if: github.event_name == 'pull_request' && github.repository == 'commaai/new-connect'
     uses: commaai/new-connect/.github/workflows/preview.yaml@master
+    secrets: inherit
     with:
       pr_number: ${{ github.event.number }}


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsecretsinherit

Has access to a test secret on my fork: https://github.com/signed-long/new-connect/actions/runs/9932149610/job/27433070605#step:2:1