### PR TITLE
lint: ignore unused vars starting with underscore

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,6 +50,19 @@ export default [
       '@stylistic/no-extra-semi': 'error',
       '@stylistic/quotes': ['error', 'single', { avoidEscape: true }],
       '@stylistic/semi': ['error', 'never'],
+
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          'args': 'all',
+          'argsIgnorePattern': '^_',
+          'caughtErrors': 'all',
+          'caughtErrorsIgnorePattern': '^_',
+          'destructuredArrayIgnorePattern': '^_',
+          'varsIgnorePattern': '^_',
+          'ignoreRestSiblings': true,
+        },
+      ],
     },
   },
 ]

--- a/src/api/derived.ts
+++ b/src/api/derived.ts
@@ -88,7 +88,7 @@ export interface TimelineStatistics {
 const getDerived = <T>(route: Route, fn: string): Promise<T[]> => {
   let urls: string[] = []
   if (route) {
-    const segmentNumbers = Array.from({ length: route.maxqlog }, (x, i) => i)
+    const segmentNumbers = Array.from({ length: route.maxqlog }, (_, i) => i)
     urls = segmentNumbers.map((i) => `${route.url}/${i}/${fn}`)
   }
   const results = urls.map((url) => fetch(url).then((res) => res.json() as T))


### PR DESCRIPTION
This is similar to the default typescript compiler behaviour