### PR TITLE
CI: add PR check to preview job

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -9,12 +9,15 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  checks: write
 
 jobs:
   preview:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 1
+    outputs:
+      pr: ${{ steps.pr.outputs.result }}
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
@@ -109,3 +112,25 @@ jobs:
           comment_tag: run_id
           pr_number: ${{ steps.pr.outputs.result }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
+  update_pr_check:
+    needs: preview
+    if: always() && github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Update PR check
+      uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.checks.create({
+            name: 'preview',
+            head_sha: '${{ github.event.workflow_run.head_sha }}',
+            status: 'completed',
+            conclusion: '${{ needs.preview.result }}',
+            output: {
+              title: 'Preview deployed',
+              summary: 'Result: ${{ needs.preview.result }}',
+            },
+            owner: 'commaai',
+            repo: '${{ github.event.repository.name }}',
+          })

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -18,7 +18,26 @@ jobs:
     timeout-minutes: 1
     outputs:
       pr: ${{ steps.pr.outputs.result }}
+      check_id: ${{ steps.check.outputs.result }}
     steps:
+      - name: Create PR check
+        uses: actions/github-script@v7
+        id: check
+        with:
+          script: |
+            const response = await github.rest.checks.create({
+              name: 'preview',
+              head_sha: '${{ github.event.workflow_run.head_sha }}',
+              status: 'in_progress',
+              output: {
+                title: 'Preview deployment',
+                summary: 'In Progress',
+              },
+              owner: 'commaai',
+              repo: '${{ github.event.repository.name }}',
+            })
+            return response.data.id
+
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
 
@@ -122,13 +141,14 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
-          github.rest.checks.create({
+          github.rest.checks.update({
+            check_run_id: ${{ needs.preview.outputs.check_id }},
             name: 'preview',
             head_sha: '${{ github.event.workflow_run.head_sha }}',
             status: 'completed',
             conclusion: '${{ needs.preview.result }}',
             output: {
-              title: 'Preview deployed',
+              title: 'Preview deployment',
               summary: 'Result: ${{ needs.preview.result }}',
             },
             owner: 'commaai',


### PR DESCRIPTION
Adds a status check to the PR for the preview job. 

https://github.com/signed-long/new-connect/pull/19/checks