### PR TITLE
fix(screenshots): support running script locally, cleanup code

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -15,7 +15,7 @@ jobs:
   preview:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 2
     outputs:
       pr: ${{ steps.pr.outputs.result }}
       check_id: ${{ steps.check.outputs.result }}
@@ -57,7 +57,6 @@ jobs:
           script: |
             const response = await github.rest.search.issuesAndPullRequests({
               q: 'repo:${{ github.repository }} is:pr sha:${{ github.event.workflow_run.head_sha }}',
-              per_page: 1,
             })
             const items = response.data.items
             if (items.length < 1) {


### PR DESCRIPTION
- Wait for network idle
- Spawn one browser instead of two
- Improve usability/ability to run locally
  - Remove dependency on /usr/bin/chromium (some people use windows... 🫠)
  - Run different contexts in parallel to save ~15s (can use more cores when running locally)

You can also test it against a production build locally like this:
```
$ bun run build && bun vite preview
(in another terminal)
$ node ./src/ci/screenshots.cjs http://localhost:4173
```

Testing on my fork: https://github.com/incognitojam/new-connect/pull/3