### PR TITLE
fix: sort routes without start_time/end_time

### DIFF
--- a/src/components/RouteCard.tsx
+++ b/src/components/RouteCard.tsx
@@ -1,33 +1,12 @@
 import { Suspense, type VoidComponent } from 'solid-js'
-import dayjs from 'dayjs'
 
-import Avatar from '~/components/material/Avatar'
-import Card, { CardContent, CardHeader } from '~/components/material/Card'
-import Icon from '~/components/material/Icon'
+import Card, { CardContent } from '~/components/material/Card'
+
 import RouteStaticMap from '~/components/RouteStaticMap'
 import RouteStatistics from '~/components/RouteStatistics'
+import { RouteHeader } from './RouteHeader'
 
 import type { RouteSegments } from '~/types'
-
-const RouteHeader = (props: { route: RouteSegments }) => {
-  const startTime = () => dayjs(props.route.start_time_utc_millis)
-  const endTime = () => dayjs(props.route.end_time_utc_millis)
-
-  const headline = () => startTime().format('ddd, MMM D, YYYY')
-  const subhead = () => `${startTime().format('h:mm A')} to ${endTime().format('h:mm A')}`
-
-  return (
-    <CardHeader
-      headline={headline()}
-      subhead={subhead()}
-      leading={
-        <Avatar>
-          <Icon>directions_car</Icon>
-        </Avatar>
-      }
-    />
-  )
-}
 
 interface RouteCardProps {
   route: RouteSegments
@@ -45,10 +24,11 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
           <RouteStaticMap route={props.route} />
         </Suspense>
       </div>
-
-      <CardContent>
-        <RouteStatistics route={props.route} />
-      </CardContent>
+      {!!props.route.end_time_utc_millis && (
+        <CardContent>
+          <RouteStatistics route={props.route} />
+        </CardContent>
+      )}
     </Card>
   )
 }

--- a/src/components/RouteHeader.tsx
+++ b/src/components/RouteHeader.tsx
@@ -1,0 +1,29 @@
+import dayjs from 'dayjs'
+
+import Avatar from '~/components/material/Avatar'
+import { CardHeader } from '~/components/material/Card'
+import Icon from '~/components/material/Icon'
+
+import type { RouteSegments } from '~/types'
+
+export const RouteHeader = (props: { route: RouteSegments }) => {
+  const startTime = () => dayjs(props.route.start_time_utc_millis ?? props.route.create_time * 1000)
+  const endTime = () => dayjs(props.route.end_time_utc_millis)
+  const headline = () => startTime().format('ddd, MMM D, YYYY')
+  const subhead = () => {
+    const startFormatted = startTime().format('h:mm A')
+    return props.route.end_time_utc_millis ? `${startFormatted} to ${endTime().format('h:mm A')}` : startFormatted
+  }
+
+  return (
+    <CardHeader
+      headline={headline()}
+      subhead={subhead()}
+      leading={
+        <Avatar>
+          <Icon>directions_car</Icon>
+        </Avatar>
+      }
+    />
+  )
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -79,7 +79,7 @@ export interface Route extends ApiResponseBase {
   procqcamera: number
   procqlog: number
   radar?: boolean
-  start_time: string
+  start_time?: string
   url: string
   user_id: string | null
   version?: string
@@ -92,9 +92,9 @@ export interface RouteShareSignature extends Record<string, string> {
 }
 
 export interface RouteSegments extends Route {
-  end_time_utc_millis: number
+  end_time_utc_millis?: number
   is_preserved: boolean
   share_exp: RouteShareSignature['exp']
   share_sig: RouteShareSignature['sig']
-  start_time_utc_millis: number
+  start_time_utc_millis?: number
 }


### PR DESCRIPTION
- falls back to `create_time` when start_time/end_time are unavailable
- refactor `<RouteHeader />` into its own file
- hide `<RouteStatistics />` if there's no trip data

closes #60
