### PR TITLE
UI: Route card expands to show quick actions

### DIFF
--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -1,4 +1,4 @@
 export const ATHENA_URL = 'https://athena.comma.ai'
 export const BASE_URL = 'https://api.comma.ai'
 export const BILLING_URL = 'https://billing.comma.ai'
-export const USERADMIN_URL_ROOT = 'https://useradmin.comma.ai'
+export const USERADMIN_URL = 'https://useradmin.comma.ai'

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -1,3 +1,4 @@
 export const ATHENA_URL = 'https://athena.comma.ai'
 export const BASE_URL = 'https://api.comma.ai'
 export const BILLING_URL = 'https://billing.comma.ai'
+export const USERADMIN_URL_ROOT = 'https://useradmin.comma.ai'

--- a/src/api/route.ts
+++ b/src/api/route.ts
@@ -19,3 +19,17 @@ export const getQCameraStreamUrl = (routeName: Route['fullname']): Promise<strin
   getRouteShareSignature(routeName).then((signature) =>
     createQCameraStreamUrl(routeName, signature),
   )
+
+export const setRoutePublic = (routeName: string, isPublic: boolean): Promise<Route> =>
+  fetcher<Route>(`/v1/route/${routeName}/`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ is_public: isPublic }),
+  })
+
+export const setRoutePreserved = (routeName: string, preserved: boolean): Promise<Route> =>
+  fetcher<Route>(`/v1/route/${routeName}/preserve`, {
+    method: preserved ? 'POST' : 'DELETE',
+  })

--- a/src/components/RouteCard.tsx
+++ b/src/components/RouteCard.tsx
@@ -37,16 +37,10 @@ interface RouteCardProps {
 const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   const [expanded, setExpanded] = createSignal(false)
 
-  const handleClick = (e: MouseEvent) => {
-    const target = e.target as HTMLElement
-    if (target.closest('.expand-button')) {
-      e.preventDefault()
-      setExpanded(!expanded())
-    }
-  }
+  const toggleExpanded = () => setExpanded(prev => !prev)
 
   return (
-    <div onClick={handleClick} class="flex max-w-md flex-col">
+    <div class="flex max-w-md flex-col">
       <Card 
         href={`/${props.route.dongle_id}/${props.route.fullname.slice(17)}`} 
         class="rounded-b-none"
@@ -66,7 +60,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
           />
         </div>
       </Show>
-      <ExpandButton expanded={expanded} />
+      <ExpandButton expanded={expanded} onToggle={toggleExpanded} />
     </div>
   )
 }
@@ -81,12 +75,12 @@ const RouteMap: VoidComponent<{ route: RouteSegments }> = (props) => (
   </div>
 )
 
-const ExpandButton: VoidComponent<{ expanded: () => boolean }> = (props) => {
-
+const ExpandButton: VoidComponent<{ expanded: () => boolean, onToggle: () => void }> = (props) => {
   return (
     <button 
-      // eslint-disable-next-line tailwindcss/no-custom-classname
-      class="expand-button flex w-full cursor-pointer justify-center rounded-b-lg bg-surface-container-lowest p-2 hover:bg-black/45"
+      class="flex w-full cursor-pointer justify-center rounded-b-lg bg-surface-container-lowest p-2 hover:bg-black/45"
+      onClick={() => props.onToggle()}
+      aria-expanded={props.expanded()}
       style={{
         'border': props.expanded() ? '2px solid' : '1px solid',
         'border-color': props.expanded() ? 'var(--color-surface-container-high)' : 'var(--color-surface-container-lowest)',

--- a/src/components/RouteCard.tsx
+++ b/src/components/RouteCard.tsx
@@ -1,4 +1,4 @@
-import { Suspense, type VoidComponent } from 'solid-js'
+import { Suspense, type VoidComponent, createSignal, Show } from 'solid-js'
 import dayjs from 'dayjs'
 
 import Avatar from '~/components/material/Avatar'
@@ -6,6 +6,7 @@ import Card, { CardContent, CardHeader } from '~/components/material/Card'
 import Icon from '~/components/material/Icon'
 import RouteStaticMap from '~/components/RouteStaticMap'
 import RouteStatistics from '~/components/RouteStatistics'
+import RouteCardExpanded from '~/components/RouteCardExpanded'
 
 import type { RouteSegments } from '~/types'
 
@@ -34,22 +35,65 @@ interface RouteCardProps {
 }
 
 const RouteCard: VoidComponent<RouteCardProps> = (props) => {
+  const [expanded, setExpanded] = createSignal(false)
+  // eslint-disable-next-line solid/reactivity
+  const routeUrl = `/${props.route.dongle_id}/${props.route.fullname.slice(17)}` // TODO: Should this be a constant??
+
+  const handleClick = (e: MouseEvent) => {
+    const target = e.target as HTMLElement
+    if (target.closest('.expand-button')) {
+      e.preventDefault()
+      setExpanded(!expanded())
+    }
+  }
+
   return (
-    <Card href={`/${props.route.dongle_id}/${props.route.fullname.slice(17)}`}>
-      <RouteHeader route={props.route} />
+    <div onClick={handleClick} class="flex max-w-md flex-col">
+      <Card href={routeUrl} class="rounded-b-none">
+        <RouteHeader route={props.route} />
+        <RouteMap route={props.route} />
+        <CardContent>
+          <RouteStatistics route={props.route} />
+        </CardContent>
+      </Card>
+      <Show when={expanded()}>
+        <div class="rounded-b-none bg-surface">
+          <RouteCardExpanded routeId={props.route.fullname.slice(17)} />
+        </div>
+      </Show>
+      <ExpandButton expanded={expanded} />
+    </div>
+  )
+}
 
-      <div class="mx-2 h-48 overflow-hidden rounded-lg">
-        <Suspense
-          fallback={<div class="skeleton-loader size-full bg-surface" />}
-        >
-          <RouteStaticMap route={props.route} />
-        </Suspense>
-      </div>
+const RouteMap: VoidComponent<{ route: RouteSegments }> = (props) => (
+  <div class="mx-2 h-48 overflow-hidden rounded-lg">
+    <Suspense
+      fallback={<div class="skeleton-loader size-full bg-surface" />}
+    >
+      <RouteStaticMap route={props.route} />
+    </Suspense>
+  </div>
+)
 
-      <CardContent>
-        <RouteStatistics route={props.route} />
-      </CardContent>
-    </Card>
+const ExpandButton: VoidComponent<{ expanded: () => boolean }> = (props) => {
+
+  return (
+    <button 
+      // eslint-disable-next-line tailwindcss/no-custom-classname
+      class="expand-button flex w-full cursor-pointer justify-center rounded-b-lg bg-surface-container-lowest p-2 hover:bg-black/35"
+      style={{
+        'border': props.expanded() ? '2px solid' : '1px solid',
+        'border-color': props.expanded() ? 'rgb(38,38,43)' : 'var(--color-surface-container-lowest)',
+        // 'transition': 'border-color 0.5s ease-out',
+      }}
+    >
+      <Icon
+        class={props.expanded() ? 'text-yellow-400' : 'text-zinc-500'}
+      >
+        {props.expanded() ? 'expand_less' : 'expand_more'}
+      </Icon>
+    </button>
   )
 }
 

--- a/src/components/RouteCard.tsx
+++ b/src/components/RouteCard.tsx
@@ -52,13 +52,11 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
         </CardContent>
       </Card>
       <Show when={expanded()}>
-        <div class="rounded-b-none bg-surface">
-          <RouteCardExpanded
-            routeName={props.route.fullname}
-            initialPublic={props.route.is_public}
-            initialPreserved={props.route.is_preserved}
-          />
-        </div>
+        <RouteCardExpanded
+          routeName={props.route.fullname}
+          initialPublic={props.route.is_public}
+          initialPreserved={props.route.is_preserved}
+        />
       </Show>
       <ExpandButton expanded={expanded} onToggle={toggleExpanded} />
     </div>

--- a/src/components/RouteCard.tsx
+++ b/src/components/RouteCard.tsx
@@ -84,7 +84,6 @@ const ExpandButton: VoidComponent<{ expanded: () => boolean, onToggle: () => voi
       style={{
         'border': props.expanded() ? '2px solid' : '1px solid',
         'border-color': props.expanded() ? 'var(--color-surface-container-high)' : 'var(--color-surface-container-lowest)',
-        // 'transition': 'border-color 0.5s ease-out',
       }}
     >
       <Icon

--- a/src/components/RouteCard.tsx
+++ b/src/components/RouteCard.tsx
@@ -50,9 +50,7 @@ const ExpandButton: VoidComponent<{ expanded: () => boolean, onToggle: () => voi
         'border-color': props.expanded() ? 'var(--color-surface-container-high)' : 'var(--color-surface-container-lowest)',
       }}
     >
-      <Icon
-        class={props.expanded() ? 'text-yellow-400' : 'text-zinc-500'}
-      >
+      <Icon class={props.expanded() ? 'text-yellow-400' : 'text-zinc-500'}>
         {props.expanded() ? 'expand_less' : 'expand_more'}
       </Icon>
     </button>
@@ -66,8 +64,6 @@ interface RouteCardProps {
 const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   const [expanded, setExpanded] = createSignal(false)
 
-  const toggleExpanded = () => setExpanded(prev => !prev)
-
   return (
     <div class="flex max-w-md flex-col">
       <Card 
@@ -80,6 +76,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
           <RouteStatistics route={props.route} />
         </CardContent>
       </Card>
+      
       <Show when={expanded()}>
         <RouteCardExpanded
           routeName={props.route.fullname}
@@ -87,7 +84,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
           initialPreserved={props.route.is_preserved}
         />
       </Show>
-      <ExpandButton expanded={expanded} onToggle={toggleExpanded} />
+      <ExpandButton expanded={expanded} onToggle={() => setExpanded(prev => !prev)} />
     </div>
   )
 }

--- a/src/components/RouteCard.tsx
+++ b/src/components/RouteCard.tsx
@@ -36,8 +36,6 @@ interface RouteCardProps {
 
 const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   const [expanded, setExpanded] = createSignal(false)
-  // eslint-disable-next-line solid/reactivity
-  const routeUrl = `/${props.route.dongle_id}/${props.route.fullname.slice(17)}` // TODO: Should this be a constant??
 
   const handleClick = (e: MouseEvent) => {
     const target = e.target as HTMLElement
@@ -49,7 +47,10 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
 
   return (
     <div onClick={handleClick} class="flex max-w-md flex-col">
-      <Card href={routeUrl} class="rounded-b-none">
+      <Card 
+        href={`/${props.route.dongle_id}/${props.route.fullname.slice(17)}`} 
+        class="rounded-b-none"
+      >
         <RouteHeader route={props.route} />
         <RouteMap route={props.route} />
         <CardContent>
@@ -58,7 +59,12 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
       </Card>
       <Show when={expanded()}>
         <div class="rounded-b-none bg-surface">
-          <RouteCardExpanded routeId={props.route.fullname.slice(17)} />
+          <RouteCardExpanded
+            dongleId={props.route.dongle_id}
+            routeName={props.route.fullname}
+            initialPublic={props.route.is_public}
+            initialPreserved={props.route.is_preserved}
+          />
         </div>
       </Show>
       <ExpandButton expanded={expanded} />

--- a/src/components/RouteCard.tsx
+++ b/src/components/RouteCard.tsx
@@ -51,7 +51,7 @@ const ExpandButton: VoidComponent<{ expanded: () => boolean, onToggle: () => voi
       }}
     >
       <Icon class={props.expanded() ? 'text-yellow-400' : 'text-zinc-500'}>
-        {props.expanded() ? 'expand_less' : 'expand_more'}
+        {props.expanded() ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
       </Icon>
     </button>
   )

--- a/src/components/RouteCard.tsx
+++ b/src/components/RouteCard.tsx
@@ -60,7 +60,6 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
       <Show when={expanded()}>
         <div class="rounded-b-none bg-surface">
           <RouteCardExpanded
-            dongleId={props.route.dongle_id}
             routeName={props.route.fullname}
             initialPublic={props.route.is_public}
             initialPreserved={props.route.is_preserved}

--- a/src/components/RouteCard.tsx
+++ b/src/components/RouteCard.tsx
@@ -30,6 +30,36 @@ const RouteHeader = (props: { route: RouteSegments }) => {
   )
 }
 
+const RouteMap: VoidComponent<{ route: RouteSegments }> = (props) => (
+  <div class="mx-2 h-48 overflow-hidden rounded-lg">
+    <Suspense
+      fallback={<div class="skeleton-loader size-full bg-surface" />}
+    >
+      <RouteStaticMap route={props.route} />
+    </Suspense>
+  </div>
+)
+
+const ExpandButton: VoidComponent<{ expanded: () => boolean, onToggle: () => void }> = (props) => {
+  return (
+    <button 
+      class="flex w-full cursor-pointer justify-center rounded-b-lg bg-surface-container-lowest p-2 hover:bg-black/45"
+      onClick={() => props.onToggle()}
+      aria-expanded={props.expanded()}
+      style={{
+        'border': props.expanded() ? '2px solid' : '1px solid',
+        'border-color': props.expanded() ? 'var(--color-surface-container-high)' : 'var(--color-surface-container-lowest)',
+      }}
+    >
+      <Icon
+        class={props.expanded() ? 'text-yellow-400' : 'text-zinc-500'}
+      >
+        {props.expanded() ? 'expand_less' : 'expand_more'}
+      </Icon>
+    </button>
+  )
+}
+
 interface RouteCardProps {
   route: RouteSegments
 }
@@ -60,36 +90,6 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
       </Show>
       <ExpandButton expanded={expanded} onToggle={toggleExpanded} />
     </div>
-  )
-}
-
-const RouteMap: VoidComponent<{ route: RouteSegments }> = (props) => (
-  <div class="mx-2 h-48 overflow-hidden rounded-lg">
-    <Suspense
-      fallback={<div class="skeleton-loader size-full bg-surface" />}
-    >
-      <RouteStaticMap route={props.route} />
-    </Suspense>
-  </div>
-)
-
-const ExpandButton: VoidComponent<{ expanded: () => boolean, onToggle: () => void }> = (props) => {
-  return (
-    <button 
-      class="flex w-full cursor-pointer justify-center rounded-b-lg bg-surface-container-lowest p-2 hover:bg-black/45"
-      onClick={() => props.onToggle()}
-      aria-expanded={props.expanded()}
-      style={{
-        'border': props.expanded() ? '2px solid' : '1px solid',
-        'border-color': props.expanded() ? 'var(--color-surface-container-high)' : 'var(--color-surface-container-lowest)',
-      }}
-    >
-      <Icon
-        class={props.expanded() ? 'text-yellow-400' : 'text-zinc-500'}
-      >
-        {props.expanded() ? 'expand_less' : 'expand_more'}
-      </Icon>
-    </button>
   )
 }
 

--- a/src/components/RouteCard.tsx
+++ b/src/components/RouteCard.tsx
@@ -87,10 +87,10 @@ const ExpandButton: VoidComponent<{ expanded: () => boolean }> = (props) => {
   return (
     <button 
       // eslint-disable-next-line tailwindcss/no-custom-classname
-      class="expand-button flex w-full cursor-pointer justify-center rounded-b-lg bg-surface-container-lowest p-2 hover:bg-black/35"
+      class="expand-button flex w-full cursor-pointer justify-center rounded-b-lg bg-surface-container-lowest p-2 hover:bg-black/45"
       style={{
         'border': props.expanded() ? '2px solid' : '1px solid',
-        'border-color': props.expanded() ? 'rgb(38,38,43)' : 'var(--color-surface-container-lowest)',
+        'border-color': props.expanded() ? 'var(--color-surface-container-high)' : 'var(--color-surface-container-lowest)',
         // 'transition': 'border-color 0.5s ease-out',
       }}
     >

--- a/src/components/RouteCard.tsx
+++ b/src/components/RouteCard.tsx
@@ -45,7 +45,6 @@ const ExpandButton: VoidComponent<{ expanded: () => boolean, onToggle: () => voi
     <button 
       class="flex w-full cursor-pointer justify-center rounded-b-lg bg-surface-container-lowest p-2 hover:bg-black/45"
       onClick={() => props.onToggle()}
-      aria-expanded={props.expanded()}
       style={{
         'border': props.expanded() ? '2px solid' : '1px solid',
         'border-color': props.expanded() ? 'var(--color-surface-container-high)' : 'var(--color-surface-container-lowest)',

--- a/src/components/RouteCardExpanded.tsx
+++ b/src/components/RouteCardExpanded.tsx
@@ -1,0 +1,95 @@
+import { createSignal, type VoidComponent } from 'solid-js'
+import Button from '~/components/material/Button'
+import Icon from '~/components/material/Icon'
+
+interface RouteCardExpandedProps {
+  routeId: string
+}
+
+const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
+  const [preserveRoute, setPreserveRoute] = createSignal(false)
+  const [makePublic, setMakePublic] = createSignal(false)
+  const [copied, setCopied] = createSignal(false)
+
+  const copyRouteId = () => {
+    void navigator.clipboard.writeText(props.routeId)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div class="flex flex-col border-x-2 border-[rgb(38,38,43)] bg-surface-container-lowest p-4">
+      {/* Route ID */}
+      <div class="mb-3 ml-2 text-body-sm text-zinc-500" style={{'font-family':"'JetBrains Mono', monospace"}}>Route ID: {props.routeId}</div>
+      {/* Preserve Route */}
+      <button
+        class="flex w-full items-center justify-between rounded-t-md border-2 border-[rgb(38,38,43)] px-5 py-3 transition-colors hover:bg-surface-container-low"
+        onClick={() => setPreserveRoute(!preserveRoute())}
+      >
+        <span class="text-body-lg">Preserve Route</span>
+
+        {/* TODO: Toggle flashes white border UI bug */}
+        {/* Toggle Button */}
+        <div
+          class={`relative h-9 w-16 rounded-full transition-colors ${
+            preserveRoute() ? 'bg-green-300' : 'border-4 border-[rgb(38,38,43)]'
+          }`}
+        >
+          <div
+            class={`absolute top-1 size-5 rounded-full bg-[rgb(38,38,43)] transition-transform duration-500 ease-in-out ${
+              preserveRoute() ? 'top-2 translate-x-9' : 'translate-x-1'
+            }`}
+          />
+        </div>
+      </button>
+      {/* Make Public */}
+      <button
+        class="flex w-full items-center justify-between rounded-b-md border-2 border-t-0 border-[rgb(38,38,43)] px-5 py-3 transition-colors hover:bg-surface-container-low"
+        onClick={() => setMakePublic(!makePublic())}
+      >
+        <span class="text-body-lg">Make Public</span>
+
+        {/* TODO: Make toggle button into own component?? */}
+        {/* Toggle Button */}
+        <div
+          class={`relative h-9 w-16 rounded-full transition-colors ${
+            makePublic() ? 'bg-green-300' : 'border-4 border-[rgb(38,38,43)]'
+          }`}
+        >
+          <div
+            class={`absolute top-1 size-5 rounded-full bg-[rgb(38,38,43)] transition-transform duration-500 ease-in-out ${
+              makePublic() ? 'top-2 translate-x-9' : 'translate-x-1'
+            }`}
+          />
+        </div>
+      </button>
+      <div class="mt-4 flex gap-2">
+        {/* Copy Route ID */}
+        <Button
+          // TODO: Make this into a component and wierd rendering of hover since it has previous compoonent styles
+          class="w-full rounded-sm border-2 border-[rgb(38,38,43)] bg-surface-container-lowest py-6 text-on-surface-variant hover:bg-surface-container-low"
+          onClick={copyRouteId}
+          leading={
+            <Icon 
+              class={copied() ? 'text-green-300' : ''}
+            >
+              {copied() ? 'check' : 'file_copy'}
+            </Icon>
+          }
+        >
+          {copied() ? 'Copied!' : 'Route ID'}
+        </Button>
+        {/* Share */}
+        <Button 
+          class="w-full rounded-sm border-2 border-[rgb(38,38,43)] bg-surface-container-lowest py-6 text-on-surface-variant hover:bg-surface-container-low" 
+          href="#" 
+          leading={<Icon>share</Icon>}
+        >
+          Share
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default RouteCardExpanded

--- a/src/components/RouteCardExpanded.tsx
+++ b/src/components/RouteCardExpanded.tsx
@@ -62,8 +62,7 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
   }
 
   const openInUseradmin = () => {
-    const params = new URLSearchParams({ onebox: props.routeName })
-    const url = `${USERADMIN_URL_ROOT}?${params.toString()}`
+    const url = `${USERADMIN_URL_ROOT}?${new URLSearchParams({ onebox: props.routeName }).toString()}`
     window.open(url, '_blank')?.focus()
   }
 

--- a/src/components/RouteCardExpanded.tsx
+++ b/src/components/RouteCardExpanded.tsx
@@ -2,7 +2,7 @@ import { createSignal, Show, type VoidComponent } from 'solid-js'
 import Button from '~/components/material/Button'
 import Icon from '~/components/material/Icon'
 import { setRoutePublic, setRoutePreserved } from '~/api/route'
-import { USERADMIN_URL_ROOT } from '~/api/config'
+import { USERADMIN_URL } from '~/api/config'
 
 interface RouteCardExpandedProps {
   routeName: string
@@ -56,7 +56,7 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
   }
 
   const openInUseradmin = () => {
-    const url = `${USERADMIN_URL_ROOT}?${new URLSearchParams({ onebox: props.routeName }).toString()}`
+    const url = `${USERADMIN_URL}?${new URLSearchParams({ onebox: props.routeName }).toString()}`
     window.open(url, '_blank')?.focus()
   }
 

--- a/src/components/RouteCardExpanded.tsx
+++ b/src/components/RouteCardExpanded.tsx
@@ -30,6 +30,7 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
   const [preserveRoute, togglePreserveRoute] = createToggle(props.initialPreserved, setRoutePreserved)
   const [makePublic, toggleMakePublic] = createToggle(props.initialPublic, setRoutePublic)
   const [error, setError] = createSignal<string | null>(null)
+  const [copied, setCopied] = createSignal(false)
 
   const handleToggle = (toggleFn: (routeName: string) => void) => {
     setError(null)
@@ -39,8 +40,6 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
       setError((err as Error).message)
     }
   }
-
-  const [copied, setCopied] = createSignal(false)
 
   const currentRouteId = () => props.routeName.replace('|', '/')
 
@@ -63,8 +62,6 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
 
   return (
     <div class="flex flex-col border-x-2 border-surface-container-high bg-surface-container-lowest p-4">
-      {/* Route ID */}
-      {/* TODO: Should I create a variable for the route name that has the | replaced with /? */}
       <div 
         class="mb-3 ml-2 text-body-sm text-zinc-500" 
         style={{'font-family':"'JetBrains Mono', monospace"}}
@@ -111,7 +108,7 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
         >
           {copied() ? 'Copied!' : 'Route ID'}
         </Button>
-        {/* Share OR USERADMIN ?? */}
+        {/* USERADMIN*/}
         <Button 
           class="w-full rounded-sm border-2 border-surface-container-high bg-surface-container-lowest py-6 text-on-surface-variant hover:bg-surface-container-low" 
           onClick={openInUseradmin}

--- a/src/components/RouteCardExpanded.tsx
+++ b/src/components/RouteCardExpanded.tsx
@@ -129,7 +129,7 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
         <ActionButton
           onClick={() => void copyCurrentRouteId()}
           icon={copied() ? 'check' : 'file_copy'}
-          label={copied() ? 'Copied!' : 'Route ID'}
+          label={copied() ? 'Copied!' : 'Copy \nRoute ID'}
           iconClass={copied() ? 'text-green-300' : ''}
         />
         <ActionButton

--- a/src/components/RouteCardExpanded.tsx
+++ b/src/components/RouteCardExpanded.tsx
@@ -110,14 +110,12 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
         </div>
       </Show>
       
-      <div class="flex flex-col overflow-hidden rounded-md border-2 border-surface-container-high">
+      <div class="divide-y-2 divide-surface-container-high overflow-hidden rounded-md border-2 border-surface-container-high">
         <ToggleButton
           label="Preserve Route"
           active={() => preserveRoute()}
           onToggle={() => void handleToggle(setRoutePreserved, preserveRoute, setPreserveRoute)}
         />
-        {/* Horizontal Divider */}
-        <div class="h-[2px] bg-surface-container-high" />
         <ToggleButton
           label="Public Access"
           active={() => makePublic()}

--- a/src/components/RouteCardExpanded.tsx
+++ b/src/components/RouteCardExpanded.tsx
@@ -5,7 +5,6 @@ import { setRoutePublic, setRoutePreserved } from '~/api/route'
 import { USERADMIN_URL_ROOT } from '~/api/config'
 
 interface RouteCardExpandedProps {
-  dongleId: string
   routeName: string
   initialPublic: boolean
   initialPreserved: boolean
@@ -72,7 +71,12 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
     <div class="flex flex-col border-x-2 border-surface-container-high bg-surface-container-lowest p-4">
       {/* Route ID */}
       {/* TODO: Should I create a variable for the route name that has the | replaced with /? */}
-      <div class="mb-3 ml-2 text-body-sm text-zinc-500" style={{'font-family':"'JetBrains Mono', monospace"}}>Route ID: {props.routeName.replace('|', '/')}</div>
+      <div 
+        class="mb-3 ml-2 text-body-sm text-zinc-500" 
+        style={{'font-family':"'JetBrains Mono', monospace"}}
+      >
+        Route ID: {props.routeName.replace('|', '/')}
+      </div>
 
       <Show when={error()}>
         <div class="mb-4 flex items-center rounded-md bg-[rgb(150,51,51)] bg-opacity-[0.31] p-4 text-red-500">

--- a/src/components/RouteCardExpanded.tsx
+++ b/src/components/RouteCardExpanded.tsx
@@ -69,7 +69,7 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
   }
 
   return (
-    <div class="flex flex-col border-x-2 border-[rgb(38,38,43)] bg-surface-container-lowest p-4">
+    <div class="flex flex-col border-x-2 border-surface-container-high bg-surface-container-lowest p-4">
       {/* Route ID */}
       {/* TODO: Should I create a variable for the route name that has the | replaced with /? */}
       <div class="mb-3 ml-2 text-body-sm text-zinc-500" style={{'font-family':"'JetBrains Mono', monospace"}}>Route ID: {props.routeName.replace('|', '/')}</div>
@@ -83,7 +83,7 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
       
       {/* Preserve Route */}
       <button
-        class="flex w-full items-center justify-between rounded-t-md border-2 border-[rgb(38,38,43)] px-5 py-3 transition-colors hover:bg-surface-container-low"
+        class="flex w-full items-center justify-between rounded-t-md border-2 border-surface-container-high px-5 py-3 transition-colors hover:bg-surface-container-low"
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         onClick={togglePreserveRoute}
       >
@@ -93,7 +93,7 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
 
       {/* Make Public */}
       <button
-        class="flex w-full items-center justify-between rounded-b-md border-2 border-t-0 border-[rgb(38,38,43)] px-5 py-3 transition-colors hover:bg-surface-container-low"
+        class="flex w-full items-center justify-between rounded-b-md border-2 border-t-0 border-surface-container-high px-5 py-3 transition-colors hover:bg-surface-container-low"
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         onClick={toggleMakePublic}
       >
@@ -105,7 +105,7 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
         {/* Copy Route ID */}
         <Button
           // TODO: Make this into a component and wierd rendering of hover since it has previous compoonent styles
-          class="w-full rounded-sm border-2 border-[rgb(38,38,43)] bg-surface-container-lowest py-6 text-on-surface-variant hover:bg-surface-container-low"
+          class="w-full rounded-sm border-2 border-surface-container-high bg-surface-container-lowest py-6 text-on-surface-variant hover:bg-surface-container-low"
           // eslint-disable-next-line @typescript-eslint/no-misused-promises
           onClick={copyCurrentRouteId}
           leading={
@@ -118,7 +118,7 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
         </Button>
         {/* Share OR USERADMIN ?? */}
         <Button 
-          class="w-full rounded-sm border-2 border-[rgb(38,38,43)] bg-surface-container-lowest py-6 text-on-surface-variant hover:bg-surface-container-low" 
+          class="w-full rounded-sm border-2 border-surface-container-high bg-surface-container-lowest py-6 text-on-surface-variant hover:bg-surface-container-low" 
           onClick={openInUseradmin}
           leading={<Icon>open_in_new</Icon>}
         >
@@ -132,11 +132,11 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
 const ToggleButton: VoidComponent<{ active: boolean }> = (props) => (
   <div
     class={`relative h-9 w-16 rounded-full transition-colors ${
-      props.active ? 'bg-green-300' : 'border-4 border-[rgb(38,38,43)]'
+      props.active ? 'bg-green-300' : 'border-4 border-surface-container-high'
     }`}
   >
     <div
-      class={`absolute top-1 size-5 rounded-full bg-[rgb(38,38,43)] transition-transform duration-500 ease-in-out ${
+      class={`absolute top-1 size-5 rounded-full bg-surface-container-high transition-transform duration-500 ease-in-out ${
         props.active ? 'top-2 translate-x-9' : 'translate-x-1'
       }`}
     />

--- a/src/components/RouteCardExpanded.tsx
+++ b/src/components/RouteCardExpanded.tsx
@@ -2,6 +2,7 @@ import { createSignal, Show, type VoidComponent } from 'solid-js'
 import Button from '~/components/material/Button'
 import Icon from '~/components/material/Icon'
 import { setRoutePublic, setRoutePreserved } from '~/api/route'
+import { USERADMIN_URL_ROOT } from '~/api/config'
 
 interface RouteCardExpandedProps {
   dongleId: string
@@ -61,6 +62,12 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
     }
   }
 
+  const openInUseradmin = () => {
+    const params = new URLSearchParams({ onebox: props.routeName })
+    const url = `${USERADMIN_URL_ROOT}?${params.toString()}`
+    window.open(url, '_blank')?.focus()
+  }
+
   return (
     <div class="flex flex-col border-x-2 border-[rgb(38,38,43)] bg-surface-container-lowest p-4">
       {/* Route ID */}
@@ -112,10 +119,10 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
         {/* Share OR USERADMIN ?? */}
         <Button 
           class="w-full rounded-sm border-2 border-[rgb(38,38,43)] bg-surface-container-lowest py-6 text-on-surface-variant hover:bg-surface-container-low" 
-          href="#" 
-          leading={<Icon>share</Icon>}
+          onClick={openInUseradmin}
+          leading={<Icon>open_in_new</Icon>}
         >
-          Share
+          View in useradmin
         </Button>
       </div>
     </div>

--- a/src/components/RouteCardExpanded.tsx
+++ b/src/components/RouteCardExpanded.tsx
@@ -60,6 +60,20 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
     window.open(url, '_blank')?.focus()
   }
 
+  const ToggleButton: VoidComponent<{
+    label: string
+    active: () => boolean
+    onToggle: () => void
+  }> = (props) => (
+    <button
+      class="flex w-full items-center justify-between px-5 py-3 transition-colors hover:bg-surface-container-low"
+      onClick={() => props.onToggle()}
+    >
+      <span class="text-body-lg">{props.label}</span>
+      <ToggleSwitchButton active={props.active()} />
+    </button>
+  )
+
   return (
     <div class="flex flex-col border-x-2 border-surface-container-high bg-surface-container-lowest p-4">
       <div 
@@ -76,23 +90,20 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
         </div>
       </Show>
       
-      {/* Preserve Route */}
-      <button
-        class="flex w-full items-center justify-between rounded-t-md border-2 border-surface-container-high px-5 py-3 transition-colors hover:bg-surface-container-low"
-        onClick={() => handleToggle(togglePreserveRoute)}
-      >
-        <span class="text-body-lg">Preserve Route</span>
-        <ToggleSwitchButton active={preserveRoute()} />
-      </button>
-
-      {/* Make Public */}
-      <button
-        class="flex w-full items-center justify-between rounded-b-md border-2 border-t-0 border-surface-container-high px-5 py-3 transition-colors hover:bg-surface-container-low"
-        onClick={() => handleToggle(toggleMakePublic)}
-      >
-        <span class="text-body-lg">Public Access</span>
-        <ToggleSwitchButton active={makePublic()} />
-      </button>
+      <div class="flex flex-col overflow-hidden rounded-md border-2 border-surface-container-high">
+        <ToggleButton
+          label="Preserve Route"
+          active={preserveRoute}
+          onToggle={() => handleToggle(togglePreserveRoute)}
+        />
+        {/* Horizontal Divider */}
+        <div class="h-[2px] bg-surface-container-high" />
+        <ToggleButton
+          label="Public Access"
+          active={makePublic}
+          onToggle={() => handleToggle(toggleMakePublic)}
+        />
+      </div>
 
       <div class="mt-4 flex gap-2">
         {/* Copy Route ID */}

--- a/src/components/RouteCardExpanded.tsx
+++ b/src/components/RouteCardExpanded.tsx
@@ -1,4 +1,4 @@
-import { createSignal, type VoidComponent } from 'solid-js'
+import { createSignal, Show, type VoidComponent } from 'solid-js'
 import Button from '~/components/material/Button'
 import Icon from '~/components/material/Icon'
 
@@ -22,6 +22,14 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
       {/* Route ID */}
       <div class="mb-3 ml-2 text-body-sm text-zinc-500" style={{'font-family':"'JetBrains Mono', monospace"}}>Route ID: {props.routeId}</div>
       {/* Preserve Route */}
+
+      {/* TODO: Create error function */}
+      <Show when={false}> 
+        <div class="mb-4 rounded-md bg-[rgb(150,51,51)] bg-opacity-[0.31] p-4 text-red-500">
+          Error: {'This is a test error'}
+        </div>
+      </Show>
+      
       <button
         class="flex w-full items-center justify-between rounded-t-md border-2 border-[rgb(38,38,43)] px-5 py-3 transition-colors hover:bg-surface-container-low"
         onClick={() => setPreserveRoute(!preserveRoute())}
@@ -47,7 +55,7 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
         class="flex w-full items-center justify-between rounded-b-md border-2 border-t-0 border-[rgb(38,38,43)] px-5 py-3 transition-colors hover:bg-surface-container-low"
         onClick={() => setMakePublic(!makePublic())}
       >
-        <span class="text-body-lg">Make Public</span>
+        <span class="text-body-lg">Public Access</span>
 
         {/* TODO: Make toggle button into own component?? */}
         {/* Toggle Button */}

--- a/src/components/RouteCardExpanded.tsx
+++ b/src/components/RouteCardExpanded.tsx
@@ -16,6 +16,8 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
   const [copied, setCopied] = createSignal(false)
   const [error, setError] = createSignal<string | null>(null)
 
+  const currentRouteId = () => props.routeName.replace('|', '/')
+
   const setTemporaryError = (message: string | null) => {
     setError(message)
     if (message) {
@@ -24,13 +26,10 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
   }
 
   const copyCurrentRouteId = async () => {
-    if (!props.routeName || !navigator.clipboard) {
-      return
-    }
+    if (!props.routeName || !navigator.clipboard) return
 
-    const currentRouteId = props.routeName.replace('|', '/')
     try {
-      await navigator.clipboard.writeText(currentRouteId)
+      await navigator.clipboard.writeText(currentRouteId())
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     } catch (err) {
@@ -74,7 +73,7 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
         class="mb-3 ml-2 text-body-sm text-zinc-500" 
         style={{'font-family':"'JetBrains Mono', monospace"}}
       >
-        Route ID: {props.routeName.replace('|', '/')}
+        Route ID: {currentRouteId()}
       </div>
 
       <Show when={error()}>

--- a/src/components/RouteCardExpanded.tsx
+++ b/src/components/RouteCardExpanded.tsx
@@ -55,30 +55,18 @@ const ToggleButton: VoidComponent<{
 const ActionButton: VoidComponent<{
   onClick: () => void
   icon: string
-  activeIcon?: string
   label: string
-  activeLabel?: string
-  isActive?: () => boolean
-}> = (props) => {
-  const isActive = () => props.isActive?.() || false
-
-  return (
-    <Button
-      class="w-full rounded-sm border-2 border-surface-container-high bg-surface-container-lowest py-8 text-on-surface-variant hover:bg-surface-container-low"
-      onClick={props.onClick}
-      leading={
-        <Icon size="34" class={isActive() ? 'text-green-300' : ''}>
-          {isActive() ? props.activeIcon || props.icon : props.icon}
-        </Icon>
-      }
-      noPadding
-    >
-      <span class="whitespace-pre-line">
-        {isActive() ? props.activeLabel || props.label : props.label}
-      </span>
-    </Button>
-  )
-}
+  iconClass?: string
+}> = (props) => (
+  <Button
+    class="w-full rounded-sm border-2 border-surface-container-high bg-surface-container-lowest py-8 text-on-surface-variant hover:bg-surface-container-low"
+    onClick={props.onClick}
+    leading={<Icon size="34" class={props.iconClass}>{props.icon}</Icon>}
+    noPadding
+  >
+    <span class="whitespace-pre-line">{props.label}</span>
+  </Button>
+)
 
 const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
   const [preserveRoute, togglePreserveRoute] = createToggle(props.initialPreserved, setRoutePreserved)
@@ -149,11 +137,9 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
       <div class="mt-4 flex gap-[.75rem]">
         <ActionButton
           onClick={() => void copyCurrentRouteId()}
-          icon="file_copy"
-          activeIcon="check"
-          label="Route ID"
-          activeLabel="Copied!"
-          isActive={copied}
+          icon={copied() ? 'check' : 'file_copy'}
+          label={copied() ? 'Copied!' : 'Route ID'}
+          iconClass={copied() ? 'text-green-300' : ''}
         />
         <ActionButton
           onClick={openInUseradmin}

--- a/src/components/RouteCardExpanded.tsx
+++ b/src/components/RouteCardExpanded.tsx
@@ -105,27 +105,29 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
         />
       </div>
 
-      <div class="mt-4 flex gap-2">
+      <div class="mt-4 flex gap-[.75rem]">
         {/* Copy Route ID */}
         <Button
           // TODO: Make this into a component and wierd rendering of hover since it has previous compoonent styles
-          class="w-full rounded-sm border-2 border-surface-container-high bg-surface-container-lowest py-6 text-on-surface-variant hover:bg-surface-container-low"
+          class="w-full rounded-sm border-2 border-surface-container-high bg-surface-container-lowest py-8 text-on-surface-variant hover:bg-surface-container-low"
           onClick={() => void copyCurrentRouteId()}
           leading={
-            <Icon class={copied() ? 'text-green-300' : ''}>
+            <Icon size="34" class={copied() ? 'text-green-300' : ''}>
               {copied() ? 'check' : 'file_copy'}
             </Icon>
           }
+          noPadding
         >
           {copied() ? 'Copied!' : 'Route ID'}
         </Button>
         {/* USERADMIN*/}
         <Button 
-          class="w-full rounded-sm border-2 border-surface-container-high bg-surface-container-lowest py-6 text-on-surface-variant hover:bg-surface-container-low" 
+          class="w-full whitespace-pre-line rounded-sm border-2 border-surface-container-high bg-surface-container-lowest py-8 text-on-surface-variant hover:bg-surface-container-low"
           onClick={openInUseradmin}
-          leading={<Icon>open_in_new</Icon>}
+          leading={<Icon size="34">open_in_new</Icon>}
+          noPadding
         >
-          View in useradmin
+          {'View in\nuseradmin'}
         </Button>
       </div>
     </div>

--- a/src/components/RouteCardExpanded.tsx
+++ b/src/components/RouteCardExpanded.tsx
@@ -77,10 +77,11 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
   return (
     <div class="flex flex-col border-x-2 border-surface-container-high bg-surface-container-lowest p-4">
       <div 
-        class="mb-3 ml-2 text-body-sm text-zinc-500" 
+        class="mb-4 ml-2 text-body-sm text-zinc-500" 
         style={{'font-family':"'JetBrains Mono', monospace"}}
       >
-        Route ID: {currentRouteId()}
+        <div>Route ID:</div>
+        <div class="mt-1 break-all md:text-body-md">{currentRouteId()}</div>
       </div>
 
       <Show when={error()}>

--- a/src/components/RouteCardExpanded.tsx
+++ b/src/components/RouteCardExpanded.tsx
@@ -26,6 +26,62 @@ function createToggle<T>(initialValue: boolean, apiCall: (routeName: string, val
   return [value, toggle] as const
 }
 
+const ToggleSwitchButton: VoidComponent<{ active: boolean }> = (props) => (
+  <div
+    class={`relative h-9 w-16 rounded-full border-4 transition-colors ${
+      props.active ? 'border-green-300 bg-green-300' : 'border-surface-container-high'
+    }`}
+  >
+    <div
+      class={`absolute top-1 size-5 rounded-full bg-surface-container-high transition-transform duration-500 ease-in-out ${
+        props.active ? 'top-1 translate-x-8' : 'translate-x-1'
+      }`}
+    />
+  </div>
+)
+
+const ToggleButton: VoidComponent<{
+  label: string
+  active: () => boolean
+  onToggle: () => void
+}> = (props) => (
+  <button
+    class="flex w-full items-center justify-between px-5 py-3 transition-colors hover:bg-surface-container-low"
+    onClick={() => props.onToggle()}
+  >
+    <span class="text-body-lg">{props.label}</span>
+    <ToggleSwitchButton active={props.active()} />
+  </button>
+)
+
+const ActionButton: VoidComponent<{
+  onClick: () => void
+  icon: string
+  activeIcon?: string
+  label: string
+  activeLabel?: string
+  isActive?: () => boolean
+}> = (props) => {
+  const isActive = () => props.isActive?.() || false
+
+  return (
+    <Button
+      class="w-full rounded-sm border-2 border-surface-container-high bg-surface-container-lowest py-8 text-on-surface-variant hover:bg-surface-container-low"
+      onClick={props.onClick}
+      leading={
+        <Icon size="34" class={isActive() ? 'text-green-300' : ''}>
+          {isActive() ? props.activeIcon || props.icon : props.icon}
+        </Icon>
+      }
+      noPadding
+    >
+      <span class="whitespace-pre-line">
+        {isActive() ? props.activeLabel || props.label : props.label}
+      </span>
+    </Button>
+  )
+}
+
 const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
   const [preserveRoute, togglePreserveRoute] = createToggle(props.initialPreserved, setRoutePreserved)
   const [makePublic, toggleMakePublic] = createToggle(props.initialPublic, setRoutePublic)
@@ -60,20 +116,6 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
     window.open(url, '_blank')?.focus()
   }
 
-  const ToggleButton: VoidComponent<{
-    label: string
-    active: () => boolean
-    onToggle: () => void
-  }> = (props) => (
-    <button
-      class="flex w-full items-center justify-between px-5 py-3 transition-colors hover:bg-surface-container-low"
-      onClick={() => props.onToggle()}
-    >
-      <span class="text-body-lg">{props.label}</span>
-      <ToggleSwitchButton active={props.active()} />
-    </button>
-  )
-
   return (
     <div class="flex flex-col border-x-2 border-surface-container-high bg-surface-container-lowest p-4">
       <div 
@@ -107,46 +149,22 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
       </div>
 
       <div class="mt-4 flex gap-[.75rem]">
-        {/* Copy Route ID */}
-        <Button
-          // TODO: Make this into a component and wierd rendering of hover since it has previous compoonent styles
-          class="w-full rounded-sm border-2 border-surface-container-high bg-surface-container-lowest py-8 text-on-surface-variant hover:bg-surface-container-low"
+        <ActionButton
           onClick={() => void copyCurrentRouteId()}
-          leading={
-            <Icon size="34" class={copied() ? 'text-green-300' : ''}>
-              {copied() ? 'check' : 'file_copy'}
-            </Icon>
-          }
-          noPadding
-        >
-          {copied() ? 'Copied!' : 'Route ID'}
-        </Button>
-        {/* USERADMIN*/}
-        <Button 
-          class="w-full whitespace-pre-line rounded-sm border-2 border-surface-container-high bg-surface-container-lowest py-8 text-on-surface-variant hover:bg-surface-container-low"
+          icon="file_copy"
+          activeIcon="check"
+          label="Route ID"
+          activeLabel="Copied!"
+          isActive={copied}
+        />
+        <ActionButton
           onClick={openInUseradmin}
-          leading={<Icon size="34">open_in_new</Icon>}
-          noPadding
-        >
-          {'View in\nuseradmin'}
-        </Button>
+          icon="open_in_new"
+          label={'View in\nuseradmin'}
+        />
       </div>
     </div>
   )
 }
-
-const ToggleSwitchButton: VoidComponent<{ active: boolean }> = (props) => (
-  <div
-    class={`relative h-9 w-16 rounded-full border-4 transition-colors ${
-      props.active ? 'border-green-300 bg-green-300' : 'border-surface-container-high'
-    }`}
-  >
-    <div
-      class={`absolute top-1 size-5 rounded-full bg-surface-container-high transition-transform duration-500 ease-in-out ${
-        props.active ? 'top-1 translate-x-8' : 'translate-x-1'
-      }`}
-    />
-  </div>
-)
 
 export default RouteCardExpanded

--- a/src/components/RouteCardExpanded.tsx
+++ b/src/components/RouteCardExpanded.tsx
@@ -127,7 +127,7 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
       </div>
 
       <Show when={error()}>
-        <div class="mb-4 flex items-center rounded-md bg-[rgb(150,51,51)] bg-opacity-[0.31] p-4 text-red-500">
+        <div class="mb-4 flex items-center rounded-md bg-red-900/30 p-4 text-red-500">
           <Icon class="mr-4 text-yellow-300">warning</Icon>
           <span style={{'font-family': "'JetBrains Mono', monospace"}}>{error()}</span>
         </div>

--- a/src/components/RouteCardExpanded.tsx
+++ b/src/components/RouteCardExpanded.tsx
@@ -134,13 +134,13 @@ const RouteCardExpanded: VoidComponent<RouteCardExpandedProps> = (props) => {
 
 const ToggleSwitchButton: VoidComponent<{ active: boolean }> = (props) => (
   <div
-    class={`relative h-9 w-16 rounded-full transition-colors ${
-      props.active ? 'bg-green-300' : 'border-4 border-surface-container-high'
+    class={`relative h-9 w-16 rounded-full border-4 transition-colors ${
+      props.active ? 'border-green-300 bg-green-300' : 'border-surface-container-high'
     }`}
   >
     <div
       class={`absolute top-1 size-5 rounded-full bg-surface-container-high transition-transform duration-500 ease-in-out ${
-        props.active ? 'top-2 translate-x-9' : 'translate-x-1'
+        props.active ? 'top-1 translate-x-8' : 'translate-x-1'
       }`}
     />
   </div>

--- a/src/components/RouteCardExpanded.tsx
+++ b/src/components/RouteCardExpanded.tsx
@@ -26,20 +26,6 @@ function createToggle<T>(initialValue: boolean, apiCall: (routeName: string, val
   return [value, toggle] as const
 }
 
-const ToggleSwitchButton: VoidComponent<{ active: boolean }> = (props) => (
-  <div
-    class={`relative h-9 w-16 rounded-full border-4 transition-colors ${
-      props.active ? 'border-green-300 bg-green-300' : 'border-surface-container-high'
-    }`}
-  >
-    <div
-      class={`absolute top-1 size-5 rounded-full bg-surface-container-high transition-transform duration-500 ease-in-out ${
-        props.active ? 'top-1 translate-x-8' : 'translate-x-1'
-      }`}
-    />
-  </div>
-)
-
 const ToggleButton: VoidComponent<{
   label: string
   active: () => boolean
@@ -50,7 +36,19 @@ const ToggleButton: VoidComponent<{
     onClick={() => props.onToggle()}
   >
     <span class="text-body-lg">{props.label}</span>
-    <ToggleSwitchButton active={props.active()} />
+    
+    {/* Toggle Switch */}
+    <div
+      class={`relative h-9 w-16 rounded-full border-4 transition-colors ${
+        props.active() ? 'border-green-300 bg-green-300' : 'border-surface-container-high'
+      }`}
+    >
+      <div
+        class={`absolute top-1 size-5 rounded-full bg-surface-container-high transition-transform duration-500 ease-in-out ${
+          props.active() ? 'top-1 translate-x-8' : 'translate-x-1'
+        }`}
+      />
+    </div>
   </button>
 )
 

--- a/src/components/material/Button.tsx
+++ b/src/components/material/Button.tsx
@@ -11,6 +11,7 @@ type ButtonProps = ButtonBaseProps & {
   loading?: boolean
   leading?: JSXElement
   trailing?: JSXElement
+  noPadding?: boolean
 }
 
 const Button: ParentComponent<ButtonProps> = (props) => {
@@ -39,8 +40,8 @@ const Button: ParentComponent<ButtonProps> = (props) => {
         'state-layer hover:elevation-1 inline-flex h-10 items-center justify-center gap-2 rounded-full py-1 contrast-100 transition',
         colorClasses(),
         disabled() && 'cursor-not-allowed opacity-50',
-        props.leading ? 'pl-4' : 'pl-6',
-        props.trailing ? 'pr-4' : 'pr-6',
+        !props.noPadding && (props.leading ? 'pl-4' : 'pl-6'),
+        !props.noPadding && (props.trailing ? 'pr-4' : 'pr-6'),
         props.class,
       )}
       {...rest}

--- a/src/components/material/Icon.tsx
+++ b/src/components/material/Icon.tsx
@@ -5,7 +5,7 @@ export type IconProps = {
   class?: string
   children: string
   filled?: boolean
-  size?: '20' | '24' | '40' | '48'
+  size?: '20' | '24' | '34' | '40' | '48'
 }
 
 const Icon: Component<IconProps> = (props) => {

--- a/src/components/material/IconButton.tsx
+++ b/src/components/material/IconButton.tsx
@@ -17,6 +17,7 @@ const IconButton: Component<IconButtonProps> = (props) => {
     ({
       '20': 'min-w-[28px] min-h-[28px]',
       '24': 'min-w-[32px] min-h-[32px]',
+      '34': 'min-w-[42px] min-h-[42px]',
       '40': 'min-w-[48px] min-h-[48px]',
       '48': 'min-w-[56px] min-h-[56px]',
     }[size()])

--- a/src/index.css
+++ b/src/index.css
@@ -180,6 +180,11 @@
       font-size: 24px;
     }
 
+    &.size-34 {
+      --font-opsz: 34;
+      font-size: 34px;
+    }
+
     &.size-40 {
       --font-opsz: 40;
       font-size: 40px;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -97,4 +97,6 @@ export interface RouteSegments extends Route {
   share_exp: RouteShareSignature['exp']
   share_sig: RouteShareSignature['sig']
   start_time_utc_millis: number
+  is_public: boolean
+  is_preserved: boolean
 }


### PR DESCRIPTION
Decided on this design versus my [popover design](https://github.com/commaai/new-connect/issues/91#issuecomment-2300172033) because this was a more straight forward, and had less complex UI layout/logic. Only slightly unrelated change I did was create a `RouteMap` component which made the return JSX  of `RouteCard.tsx` easier to read. Photos below are up to date with recent commits

This resolves issue #91. 

## Added
- Preserve/unpreserve Routes
- Enable/disable Public Access
- Copy Route ID
- View RouteID
- Ability to view route in useradmin
- Error when toggle doesn't update

<br>

## Card expanded
![PR-100-screenshot](https://github.com/user-attachments/assets/3709aa3d-b0eb-419e-ac7b-be8a30a7516e)


<br>

## Interacting w/UI changes while showing network tab:
https://github.com/user-attachments/assets/ecd27cf2-89e1-4fa6-990e-171fef263243



<br>

## Error state of toggle
<img width="460" alt="errorState-PR--100" src="https://github.com/user-attachments/assets/e557ca39-ace7-4a72-9f62-7f4a339b9889">




