### PR TITLE
UI bug: Unintended movement when zooming in or out

### DIFF
--- a/src/components/material/Drawer.tsx
+++ b/src/components/material/Drawer.tsx
@@ -35,7 +35,7 @@ const Drawer: ParentComponent<DrawerProps> = (props) => {
       </nav>
 
       <main
-        class="absolute inset-y-0 w-screen overflow-y-auto bg-background transition-drawer duration-500"
+        class="absolute inset-y-0 w-full overflow-y-auto bg-background transition-drawer duration-500"
         style={{ left: props.open ? `${drawerWidth}px` : 0 }}
       >
         {props.children}


### PR DESCRIPTION
<table>
  <tr>
    <th>Current UI</th>
    <th>Proposed UI</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/7f5e0c4e-73da-4bc1-946f-8ef37bc54795" alt="Current UI" width="100%"></td>
    <td><img src="https://github.com/user-attachments/assets/52413aff-03e1-424c-a7d3-c09348ce30be" alt="Proposed UI" width="100%"></td>
  </tr>
</table>



- The vertical scrollbar is shifting because the content width calculation doesn't account for the scrollbar width when using VW(w-screen)
- UI movement happens when the drawer is open and closed, and when viewing a route
- Safari is the browser that only shows movement when the drawer is open

<br>
<br>

# Testing bug on different browsers

## Firefox
![firefox](https://github.com/user-attachments/assets/42e51b60-e9a4-4ca9-b684-eebe1fbc49c8)

<br>

## Google Chrome
![chrome](https://github.com/user-attachments/assets/680c23d1-66a8-4126-ae19-2f4a105045d6)

<br>

## Safari - only shows the movement when drawer is open
![safari](https://github.com/user-attachments/assets/e22eb176-21e6-44a7-a6bb-7e834092dd46)
