### PR TITLE
UI:  Always show drawer when on desktop(updated)

### DIFF
--- a/src/components/TopHeader.tsx
+++ b/src/components/TopHeader.tsx
@@ -15,7 +15,15 @@ const TopHeader: Component = () => {
             menu
           </IconButton>
         )}
-        <h1 class="ml-2 text-3xl font-bold">connect</h1>
+        <h1>
+          <a
+            href="/"
+            class="ml-2 text-3xl font-bold hover:opacity-80"
+            onClick={() => isDrawerOpen() && toggleDrawer()}
+          >
+            connect
+          </a>
+        </h1>
       </div>
       <IconButton
         href={`/${params.dongleId}/settings`}

--- a/src/components/TopHeader.tsx
+++ b/src/components/TopHeader.tsx
@@ -4,7 +4,7 @@ import IconButton from '~/components/material/IconButton'
 import { DashboardContext } from '~/pages/dashboard/Dashboard'
 
 const TopHeader: Component = () => {
-  const { toggleDrawer, isDesktop } = useContext(DashboardContext)!
+  const { toggleDrawer, isDesktop, isDrawerOpen } = useContext(DashboardContext)!
   const params = useParams()
 
   return (
@@ -17,7 +17,11 @@ const TopHeader: Component = () => {
         )}
         <h1 class="ml-2 text-3xl font-bold">connect</h1>
       </div>
-      <IconButton href={`/${params.dongleId}/settings`} class="text-white">
+      <IconButton
+        href={`/${params.dongleId}/settings`}
+        class="text-white"
+        onClick={() => isDrawerOpen() && toggleDrawer()}
+      >
         settings
       </IconButton>
     </header>

--- a/src/components/TopHeader.tsx
+++ b/src/components/TopHeader.tsx
@@ -1,11 +1,10 @@
-import { useParams } from '@solidjs/router'
 import { Component, useContext } from 'solid-js'
 import IconButton from '~/components/material/IconButton'
 import { DashboardContext } from '~/pages/dashboard/Dashboard'
 
 const TopHeader: Component = () => {
-  const { toggleDrawer, isDesktop, isDrawerOpen } = useContext(DashboardContext)!
-  const params = useParams()
+  const { toggleDrawer, isDesktop, isDrawerOpen, dongleId } = useContext(DashboardContext)!
+  const settingsUrl = () => `/${dongleId()}/settings`
 
   return (
     <header class="fixed inset-x-0 top-0 z-10 flex h-[var(--top-header-height)] items-center justify-between border-b-8 border-black bg-[#09090C] p-4 text-white">
@@ -26,7 +25,7 @@ const TopHeader: Component = () => {
         </h1>
       </div>
       <IconButton
-        href={`/${params.dongleId}/settings`}
+        href={settingsUrl()}
         class="text-white"
         onClick={() => isDrawerOpen() && toggleDrawer()}
       >

--- a/src/components/TopHeader.tsx
+++ b/src/components/TopHeader.tsx
@@ -1,0 +1,27 @@
+import { useParams } from '@solidjs/router'
+import { Component, useContext } from 'solid-js'
+import IconButton from '~/components/material/IconButton'
+import { DashboardContext } from '~/pages/dashboard/Dashboard'
+
+const TopHeader: Component = () => {
+  const { toggleDrawer, isDesktop } = useContext(DashboardContext)!
+  const params = useParams()
+
+  return (
+    <header class="fixed inset-x-0 top-0 z-10 flex h-[var(--top-header-height)] items-center justify-between border-b-8 border-black bg-[#09090C] p-4 text-white">
+      <div class="flex items-center">
+        {!isDesktop() && (
+          <IconButton onClick={toggleDrawer} class="text-white">
+            menu
+          </IconButton>
+        )}
+        <h1 class="ml-2 text-3xl font-bold">connect</h1>
+      </div>
+      <IconButton href={`/${params.dongleId}/settings`} class="text-white">
+        settings
+      </IconButton>
+    </header>
+  )
+}
+
+export default TopHeader

--- a/src/components/material/Drawer.tsx
+++ b/src/components/material/Drawer.tsx
@@ -21,7 +21,6 @@ const Drawer: ParentComponent<DrawerProps> = (props) => {
         class="hide-scrollbar fixed left-0 w-screen touch-pan-y overflow-y-auto overscroll-y-contain transition-drawer duration-500"
         style={{
           left: props.open ? 0 : `${-drawerWidth()}px`,
-          opacity: props.open ? 1 : 0.5,
           width: `${drawerWidth()}px`,
           top: 'var(--top-header-height)',
           bottom: 0,

--- a/src/components/material/Drawer.tsx
+++ b/src/components/material/Drawer.tsx
@@ -10,7 +10,7 @@ type DrawerProps = {
 }
 
 const Drawer: ParentComponent<DrawerProps> = (props) => {
-  const { isDesktop, showHeader } = useContext(DashboardContext)!
+  const { isDesktop } = useContext(DashboardContext)!
   const dimensions = useDimensions()
 
   const drawerWidth = () => isDesktop() ? 300 : dimensions().width
@@ -35,7 +35,7 @@ const Drawer: ParentComponent<DrawerProps> = (props) => {
         style={{
           left: props.open ? `${drawerWidth()}px` : 0,
           right: 0,
-          top: showHeader() ? 'var(--top-header-height)' : 0,
+          top: 'var(--top-header-height)',
           bottom: 0,
         }}
       >

--- a/src/components/material/Drawer.tsx
+++ b/src/components/material/Drawer.tsx
@@ -18,7 +18,7 @@ const Drawer: ParentComponent<DrawerProps> = (props) => {
   return (
     <>
       <nav
-        class="hide-scrollbar fixed left-0 w-screen touch-pan-y overflow-y-auto overscroll-y-contain transition-drawer duration-500"
+        class="hide-scrollbar fixed left-0 w-screen touch-pan-y overflow-y-auto overscroll-y-contain transition-all duration-300"
         style={{
           left: props.open ? 0 : `${-drawerWidth()}px`,
           width: `${drawerWidth()}px`,
@@ -31,10 +31,11 @@ const Drawer: ParentComponent<DrawerProps> = (props) => {
         </div>
       </nav>
       <main
-        class="absolute overflow-y-auto bg-background transition-drawer duration-500"
+        class="absolute overflow-y-auto bg-background transition-all duration-300"
         style={{
           left: props.open ? `${drawerWidth()}px` : 0,
-          right: 0,
+          width: isDesktop() ? `calc(100% - ${props.open ? drawerWidth() : 0}px)` : '100%',
+          transform: isDesktop() ? 'none' : props.open ? `translateX(${drawerWidth()}px)` : 'translateX(0)',
           top: 'var(--top-header-height)',
           bottom: 0,
         }}

--- a/src/components/material/Drawer.tsx
+++ b/src/components/material/Drawer.tsx
@@ -15,6 +15,11 @@ const Drawer: ParentComponent<DrawerProps> = (props) => {
 
   const drawerWidth = () => isDesktop() ? 300 : dimensions().width
 
+  const getResponsiveWidth = () => {
+    if (!isDesktop()) return '100%'
+    return `calc(100% - ${props.open ? drawerWidth() : 0}px)`
+  }
+
   return (
     <>
       <nav
@@ -34,7 +39,7 @@ const Drawer: ParentComponent<DrawerProps> = (props) => {
         class="absolute overflow-y-auto bg-background transition-all duration-300"
         style={{
           left: props.open ? `${drawerWidth()}px` : 0,
-          width: isDesktop() ? `calc(100% - ${props.open ? drawerWidth() : 0}px)` : '100%',
+          width: getResponsiveWidth(),
           transform: isDesktop() ? 'none' : props.open ? `translateX(${drawerWidth()}px)` : 'translateX(0)',
           top: 'var(--top-header-height)',
           bottom: 0,

--- a/src/components/material/Drawer.tsx
+++ b/src/components/material/Drawer.tsx
@@ -35,7 +35,7 @@ const Drawer: ParentComponent<DrawerProps> = (props) => {
       </nav>
 
       <main
-        class="absolute inset-y-0 w-screen overflow-y-auto bg-background transition-drawer duration-500"
+        class="absolute inset-y-0 w-full overflow-y-auto bg-background transition-drawer duration-500"
         style={{ left: props.open ? `${drawerWidth}px` : 0 }}
       >
         {props.children}

--- a/src/components/material/Drawer.tsx
+++ b/src/components/material/Drawer.tsx
@@ -23,11 +23,10 @@ const Drawer: ParentComponent<DrawerProps> = (props) => {
   return (
     <>
       <nav
-        class="hide-scrollbar fixed left-0 top-[var(--top-header-height)] w-screen touch-pan-y overflow-y-auto overscroll-y-contain transition-all duration-300"
+        class="hide-scrollbar fixed bottom-0 left-0 top-[var(--top-header-height)] w-screen touch-pan-y overflow-y-auto overscroll-y-contain transition-all duration-300"
         style={{
           left: props.open ? 0 : `${-drawerWidth()}px`,
           width: `${drawerWidth()}px`,
-          bottom: 0,
         }}
       >
         <div class="flex h-full flex-col bg-surface-container-low text-on-surface-variant">
@@ -35,12 +34,11 @@ const Drawer: ParentComponent<DrawerProps> = (props) => {
         </div>
       </nav>
       <main
-        class="absolute top-[var(--top-header-height)] overflow-y-auto bg-background transition-all duration-300"
+        class="absolute bottom-0 top-[var(--top-header-height)] overflow-y-auto bg-background transition-all duration-300"
         style={{
           left: props.open ? `${drawerWidth()}px` : 0,
           width: getResponsiveWidth(),
           transform: isDesktop() ? 'none' : props.open ? `translateX(${drawerWidth()}px)` : 'translateX(0)',
-          bottom: 0,
         }}
       >
         {props.children}

--- a/src/components/material/Drawer.tsx
+++ b/src/components/material/Drawer.tsx
@@ -23,7 +23,7 @@ const Drawer: ParentComponent<DrawerProps> = (props) => {
   return (
     <>
       <nav
-        class="hide-scrollbar fixed bottom-0 left-0 top-[var(--top-header-height)] touch-pan-y overflow-y-auto overscroll-y-contain transition-all duration-300"
+        class="hide-scrollbar fixed bottom-0 left-0 top-[var(--top-header-height)] touch-pan-y overflow-y-auto overscroll-y-contain transition-drawer duration-300"
         style={{
           left: props.open ? 0 : `${-drawerWidth()}px`,
           width: `${drawerWidth()}px`,
@@ -34,7 +34,7 @@ const Drawer: ParentComponent<DrawerProps> = (props) => {
         </div>
       </nav>
       <main
-        class="absolute bottom-0 top-[var(--top-header-height)] overflow-y-auto bg-background transition-all duration-300"
+        class="absolute bottom-0 top-[var(--top-header-height)] overflow-y-auto bg-background transition-drawer duration-300"
         style={{
           left: props.open ? `${drawerWidth()}px` : 0,
           width: getResponsiveWidth(),

--- a/src/components/material/Drawer.tsx
+++ b/src/components/material/Drawer.tsx
@@ -41,16 +41,6 @@ const Drawer: ParentComponent<DrawerProps> = (props) => {
         }}
       >
         {props.children}
-        {!isDesktop() && (
-          <div
-            class="absolute inset-0 bg-background transition-drawer duration-500"
-            style={{
-              'pointer-events': props.open ? undefined : 'none',
-              opacity: props.open ? 0.5 : 0,
-            }}
-            onClick={props.onClose}
-          />
-        )}
       </main>
     </>
   )

--- a/src/components/material/Drawer.tsx
+++ b/src/components/material/Drawer.tsx
@@ -23,11 +23,10 @@ const Drawer: ParentComponent<DrawerProps> = (props) => {
   return (
     <>
       <nav
-        class="hide-scrollbar fixed left-0 w-screen touch-pan-y overflow-y-auto overscroll-y-contain transition-all duration-300"
+        class="hide-scrollbar fixed left-0 top-[var(--top-header-height)] w-screen touch-pan-y overflow-y-auto overscroll-y-contain transition-all duration-300"
         style={{
           left: props.open ? 0 : `${-drawerWidth()}px`,
           width: `${drawerWidth()}px`,
-          top: 'var(--top-header-height)',
           bottom: 0,
         }}
       >
@@ -36,12 +35,11 @@ const Drawer: ParentComponent<DrawerProps> = (props) => {
         </div>
       </nav>
       <main
-        class="absolute overflow-y-auto bg-background transition-all duration-300"
+        class="absolute top-[var(--top-header-height)] overflow-y-auto bg-background transition-all duration-300"
         style={{
           left: props.open ? `${drawerWidth()}px` : 0,
           width: getResponsiveWidth(),
           transform: isDesktop() ? 'none' : props.open ? `translateX(${drawerWidth()}px)` : 'translateX(0)',
-          top: 'var(--top-header-height)',
           bottom: 0,
         }}
       >

--- a/src/components/material/Drawer.tsx
+++ b/src/components/material/Drawer.tsx
@@ -23,7 +23,7 @@ const Drawer: ParentComponent<DrawerProps> = (props) => {
   return (
     <>
       <nav
-        class="hide-scrollbar fixed bottom-0 left-0 top-[var(--top-header-height)] w-screen touch-pan-y overflow-y-auto overscroll-y-contain transition-all duration-300"
+        class="hide-scrollbar fixed bottom-0 left-0 top-[var(--top-header-height)] touch-pan-y overflow-y-auto overscroll-y-contain transition-all duration-300"
         style={{
           left: props.open ? 0 : `${-drawerWidth()}px`,
           width: `${drawerWidth()}px`,

--- a/src/components/material/Drawer.tsx
+++ b/src/components/material/Drawer.tsx
@@ -1,52 +1,56 @@
 import type { JSXElement, ParentComponent } from 'solid-js'
-
+import { useContext } from 'solid-js'
+import { DashboardContext } from '~/pages/dashboard/Dashboard'
 import { useDimensions } from '~/utils/window'
 
 type DrawerProps = {
   drawer: JSXElement
   open: boolean
-  onOpen?: () => void
-  onClose?: () => void
+  onClose: () => void
 }
 
-const PEEK = 56
-
 const Drawer: ParentComponent<DrawerProps> = (props) => {
+  const { isDesktop, showHeader } = useContext(DashboardContext)!
   const dimensions = useDimensions()
 
-  const isMobile = dimensions().width < 500
-  const drawerWidth = isMobile ? dimensions().width - PEEK : 350
-
-  const onClose = () => props.onClose?.()
+  const drawerWidth = () => isDesktop() ? 300 : dimensions().width
 
   return (
     <>
       <nav
-        class="hide-scrollbar fixed inset-y-0 left-0 h-full w-screen touch-pan-y overflow-y-auto overscroll-y-contain transition-drawer duration-500"
+        class="hide-scrollbar fixed left-0 w-screen touch-pan-y overflow-y-auto overscroll-y-contain transition-drawer duration-500"
         style={{
-          left: props.open ? 0 : `${-PEEK}px`,
+          left: props.open ? 0 : `${-drawerWidth()}px`,
           opacity: props.open ? 1 : 0.5,
-          width: `${drawerWidth}px`,
+          width: `${drawerWidth()}px`,
+          top: 'var(--top-header-height)',
+          bottom: 0,
         }}
       >
-        <div class="flex size-full flex-col rounded-r-lg bg-surface-container-low text-on-surface-variant sm:rounded-r-none">
+        <div class="flex h-full flex-col bg-surface-container-low text-on-surface-variant">
           {props.drawer}
         </div>
       </nav>
-
       <main
-        class="absolute inset-y-0 w-full overflow-y-auto bg-background transition-drawer duration-500"
-        style={{ left: props.open ? `${drawerWidth}px` : 0 }}
+        class="absolute overflow-y-auto bg-background transition-drawer duration-500"
+        style={{
+          left: props.open ? `${drawerWidth()}px` : 0,
+          right: 0,
+          top: showHeader() ? 'var(--top-header-height)' : 0,
+          bottom: 0,
+        }}
       >
         {props.children}
-        <div
-          class="absolute inset-0 bg-background transition-drawer duration-500"
-          style={{
-            'pointer-events': props.open ? undefined : 'none',
-            opacity: props.open ? 0.5 : 0,
-          }}
-          onClick={onClose}
-        />
+        {!isDesktop() && (
+          <div
+            class="absolute inset-0 bg-background transition-drawer duration-500"
+            style={{
+              'pointer-events': props.open ? undefined : 'none',
+              opacity: props.open ? 0.5 : 0,
+            }}
+            onClick={props.onClose}
+          />
+        )}
       </main>
     </>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -54,6 +54,8 @@
     --color-surface-container: rgb(239 237 244);
     --color-surface-container-high: rgb(233 231 239);
     --color-surface-container-highest: rgb(228 225 233);
+
+    --top-header-height: 64px;
   }
 
   .dark,

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -81,7 +81,7 @@ const DashboardLayout: Component<RouteSectionProps> = () => {
     }
   }
 
-  const showHeader = () => isDesktop() || (!dateStr() && dongleId() !== 'pair')
+  const showHeader = () => true
 
   const [devices] = createResource(getDevices)
   const [profile] = createResource(getProfile)

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -105,7 +105,7 @@ const DashboardLayout: Component<RouteSectionProps> = () => {
         onClose={() => setIsDrawerOpen(false)}
         drawer={<DashboardDrawer onClose={() => setIsDrawerOpen(false)} devices={devices()} />}
       >
-        <div class="max-w-3xl">
+        <div class="max-w-5xl">
           <Switch
             fallback={
               <TopAppBar

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -100,7 +100,7 @@ const DashboardLayout: Component<RouteSectionProps> = () => {
         onClose={onClose}
         drawer={<DashboardDrawer onClose={onClose} devices={devices()} />}
       >
-        <div class="mx-auto max-w-3xl">
+        <div class="max-w-3xl">
           <Switch
             fallback={
               <TopAppBar

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -35,7 +35,6 @@ type DashboardState = {
   isDrawerOpen: () => boolean
   toggleDrawer: () => void
   isDesktop: () => boolean
-  showHeader: () => boolean
 }
 
 export const DashboardContext = createContext<DashboardState>()
@@ -81,8 +80,6 @@ const DashboardLayout: Component<RouteSectionProps> = () => {
     }
   }
 
-  const showHeader = () => true
-
   const [devices] = createResource(getDevices)
   const [profile] = createResource(getProfile)
 
@@ -96,10 +93,8 @@ const DashboardLayout: Component<RouteSectionProps> = () => {
   }
 
   return (
-    <DashboardContext.Provider value={{ isDrawerOpen, toggleDrawer, isDesktop, showHeader }}>
-      <Show when={showHeader()}>
-        <TopHeader />
-      </Show>
+    <DashboardContext.Provider value={{ isDrawerOpen, toggleDrawer, isDesktop }}>
+      <TopHeader />
       <Drawer
         open={isDrawerOpen() || isDesktop()}
         onClose={() => setIsDrawerOpen(false)}

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -35,6 +35,7 @@ type DashboardState = {
   isDrawerOpen: () => boolean
   toggleDrawer: () => void
   isDesktop: () => boolean
+  dongleId: () => string | undefined
 }
 
 export const DashboardContext = createContext<DashboardState>()
@@ -93,7 +94,7 @@ const DashboardLayout: Component<RouteSectionProps> = () => {
   }
 
   return (
-    <DashboardContext.Provider value={{ isDrawerOpen, toggleDrawer, isDesktop }}>
+    <DashboardContext.Provider value={{ isDrawerOpen, toggleDrawer, isDesktop, dongleId }}>
       <TopHeader />
       <Drawer
         open={isDrawerOpen() || isDesktop()}

--- a/src/pages/dashboard/activities/DeviceActivity.tsx
+++ b/src/pages/dashboard/activities/DeviceActivity.tsx
@@ -1,4 +1,4 @@
-import { createResource, Suspense, useContext, createSignal, For, Show } from 'solid-js'
+import { createResource, Suspense, createSignal, For, Show } from 'solid-js'
 import type { VoidComponent } from 'solid-js'
 
 import { getDevice } from '~/api/devices'
@@ -6,13 +6,11 @@ import { ATHENA_URL } from '~/api/config'
 import { getAccessToken } from '~/api/auth/client'
 
 import IconButton from '~/components/material/IconButton'
-import TopAppBar from '~/components/material/TopAppBar'
 import DeviceLocation from '~/components/DeviceLocation'
 import DeviceStatistics from '~/components/DeviceStatistics'
 import { getDeviceName } from '~/utils/device'
 
 import RouteList from '../components/RouteList'
-import { DashboardContext } from '../Dashboard'
 
 type DeviceActivityProps = {
   dongleId: string
@@ -26,7 +24,6 @@ interface SnapshotResponse {
 }
 
 const DeviceActivity: VoidComponent<DeviceActivityProps> = (props) => {
-  const { toggleDrawer } = useContext(DashboardContext)!
 
   const [device] = createResource(() => props.dongleId, getDevice)
   const [deviceName] = createResource(device, getDeviceName)
@@ -104,13 +101,7 @@ const DeviceActivity: VoidComponent<DeviceActivityProps> = (props) => {
 
   return (
     <>
-      <TopAppBar
-        leading={<IconButton onClick={toggleDrawer}>menu</IconButton>}
-        trailing={<IconButton href={`/${props.dongleId}/settings`}>settings</IconButton>}
-      >
-        {deviceName()}
-      </TopAppBar>
-      <div class="flex flex-col gap-4 px-4 pb-4">
+      <div class="mt-5 flex flex-col gap-4 px-6 pb-4">
         <div class="h-min overflow-hidden rounded-lg bg-surface-container-low">
           <Show when={deviceName()} fallback={<div class="skeleton-loader size-full" />}>
             <DeviceLocation dongleId={props.dongleId} deviceName={deviceName()!} />

--- a/src/utils/useDeviceList.tsx
+++ b/src/utils/useDeviceList.tsx
@@ -5,7 +5,7 @@ import storage from './storage'
 import { DashboardContext } from '~/pages/dashboard/Dashboard'
 
 export default function useDeviceList() {
-  const { setDrawer } = useContext(DashboardContext)!
+  const { toggleDrawer, isDesktop } = useContext(DashboardContext)!
   const location = useLocation()
 
   const isSelected = (device: Device) => {
@@ -14,7 +14,9 @@ export default function useDeviceList() {
 
   const onClick = (device: Device) => {
     return () => {
-      setDrawer(false)
+      if (!isDesktop()) {
+        toggleDrawer()
+      }
       storage.setItem('lastSelectedDongleId', device.dongle_id)
     }
   }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -208,7 +208,7 @@ export default {
       },
       transitionProperty: {
         indeterminate: 'transform, background-color',
-        drawer: 'left, opacity, width',
+        drawer: 'left, width',
       },
     },
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -208,7 +208,7 @@ export default {
       },
       transitionProperty: {
         indeterminate: 'transform, background-color',
-        drawer: 'left, width',
+        drawer: 'transform, left, width',
       },
     },
   },


### PR DESCRIPTION
- text logo is clickable and takes you back home
- `<main>` content is responsive and drawer will pull out if screen is wide enough
- added warning icon when there is "no device" in drawer
- resolves issue #73 

## Proposed UI 📹
https://github.com/user-attachments/assets/56e706a2-4315-4e60-b520-f3082f9f31a8

