### PR TITLE
Dashboard: use two pane layout on larger screens

### DIFF
--- a/src/components/material/Drawer.tsx
+++ b/src/components/material/Drawer.tsx
@@ -32,7 +32,7 @@ interface DrawerProps {
 const Drawer: ParentComponent<DrawerProps> = (props) => {
   const dimensions = useDimensions()
   const drawerWidth = () => Math.min(dimensions().width - PEEK, 360)
-  const modal = () => dimensions().width < 840
+  const modal = () => dimensions().width < 1280
   const contentWidth = () => `calc(100% - ${modal() ? 0 : drawerWidth()}px)`
 
   const [open, setOpen] = createSignal(false)

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -26,13 +26,13 @@ interface DashboardDrawerProps {
 }
 
 const DashboardDrawer: VoidComponent<DashboardDrawerProps> = (props) => {
-  const { setOpen } = useDrawerContext()
+  const { modal, setOpen } = useDrawerContext()
   const onClose = () => setOpen(false)
   return (
     <>
       <TopAppBar
         component="h1"
-        leading={<IconButton onClick={onClose}>arrow_back</IconButton>}
+        leading={<Show when={modal()}><IconButton onClick={onClose}>arrow_back</IconButton></Show>}
       >
         comma connect
       </TopAppBar>

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -61,7 +61,7 @@ const TwoPaneLayout: Component<{
     <div class="relative size-full overflow-hidden">
       <div
         class={clsx(
-          'mx-auto size-full max-w-7xl md:grid md:grid-cols-2 lg:gap-2',
+          'mx-auto size-full max-w-screen-2xl md:grid md:grid-cols-2 lg:gap-2',
           // Flex layout for mobile with horizontal transition
           'flex transition-transform duration-300 ease-in-out',
           props.paneTwoContent ? '-translate-x-full md:translate-x-0' : 'translate-x-0',

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -1,11 +1,4 @@
-import {
-  createResource,
-  lazy,
-  Match,
-  Show,
-  SuspenseList,
-  Switch,
-} from 'solid-js'
+import { createResource, lazy, Match, Show, SuspenseList, Switch } from 'solid-js'
 import type { Component, JSXElement, VoidComponent } from 'solid-js'
 import { Navigate, type RouteSectionProps, useLocation } from '@solidjs/router'
 import clsx from 'clsx'

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -95,38 +95,36 @@ const DashboardLayout: Component<RouteSectionProps> = () => {
 
   return (
     <Drawer drawer={<DashboardDrawer devices={devices()} />}>
-      <div class="mx-auto max-w-3xl">
-        <Switch fallback={<TopAppBar leading={<DrawerToggleButton />}>No device</TopAppBar>}>
-          <Match when={!!profile.error}>
-            <Navigate href="/login" />
-          </Match>
-          <Match when={dongleId() === 'pair' || pairToken()}>
-            <PairActivity />
-          </Match>
-          <Match when={dongleId()} keyed>{(id) => (
-            <TwoPaneLayout
-              paneOne={<DeviceActivity dongleId={id} />}
-              paneTwo={<Switch
-                fallback={<div class="hidden size-full flex-col items-center justify-center gap-4 md:flex">
-                  <Icon size="48">search</Icon>
-                  <span class="text-title-md">Select a route to view</span>
-                </div>}
-              >
-                <Match when={dateStr() === 'settings' || dateStr() === 'prime'}>
-                  <SettingsActivity dongleId={id} />
-                </Match>
-                <Match when={dateStr()} keyed>
-                  {(date) => <RouteActivity dongleId={id} dateStr={date} />}
-                </Match>
-              </Switch>}
-              paneTwoContent={!!dateStr()}
-            />
-          )}</Match>
-          <Match when={getDefaultDongleId()} keyed>
-            {(defaultDongleId) => <Navigate href={`/${defaultDongleId}`} />}
-          </Match>
-        </Switch>
-      </div>
+      <Switch fallback={<TopAppBar leading={<DrawerToggleButton />}>No device</TopAppBar>}>
+        <Match when={!!profile.error}>
+          <Navigate href="/login" />
+        </Match>
+        <Match when={dongleId() === 'pair' || pairToken()}>
+          <PairActivity />
+        </Match>
+        <Match when={dongleId()} keyed>{(id) => (
+          <TwoPaneLayout
+            paneOne={<DeviceActivity dongleId={id} />}
+            paneTwo={<Switch
+              fallback={<div class="hidden size-full flex-col items-center justify-center gap-4 md:flex">
+                <Icon size="48">search</Icon>
+                <span class="text-title-md">Select a route to view</span>
+              </div>}
+            >
+              <Match when={dateStr() === 'settings' || dateStr() === 'prime'}>
+                <SettingsActivity dongleId={id} />
+              </Match>
+              <Match when={dateStr()} keyed>
+                {(date) => <RouteActivity dongleId={id} dateStr={date} />}
+              </Match>
+            </Switch>}
+            paneTwoContent={!!dateStr()}
+          />
+        )}</Match>
+        <Match when={getDefaultDongleId()} keyed>
+          {(defaultDongleId) => <Navigate href={`/${defaultDongleId}`} />}
+        </Match>
+      </Switch>
     </Drawer>
   )
 }

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -11,6 +11,7 @@ import storage from '~/utils/storage'
 import Button from '~/components/material/Button'
 import Drawer, { DrawerToggleButton, useDrawerContext } from '~/components/material/Drawer'
 import Icon from '~/components/material/Icon'
+import IconButton from '~/components/material/IconButton'
 import TopAppBar from '~/components/material/TopAppBar'
 
 import DeviceList from './components/DeviceList'
@@ -29,7 +30,10 @@ const DashboardDrawer: VoidComponent<DashboardDrawerProps> = (props) => {
   const onClose = () => setOpen(false)
   return (
     <>
-      <TopAppBar component="h1">
+      <TopAppBar
+        component="h1"
+        leading={<IconButton onClick={onClose}>arrow_back</IconButton>}
+      >
         comma connect
       </TopAppBar>
       <h2 class="mx-4 mb-2 text-label-sm">

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -8,13 +8,12 @@ import {
 
 import { getRoute } from '~/api/route'
 
-import IconButton from '~/components/material/IconButton'
-import TopAppBar from '~/components/material/TopAppBar'
-
 import RouteStaticMap from '~/components/RouteStaticMap'
 import RouteStatistics from '~/components/RouteStatistics'
 import Timeline from '~/components/Timeline'
 import { parseDateStr } from '~/utils/date'
+
+import ActivityBar from '../components/ActivityBar'
 
 const RouteVideoPlayer = lazy(() => import('~/components/RouteVideoPlayer'))
 
@@ -38,9 +37,9 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
 
   return (
     <>
-      <TopAppBar leading={<IconButton href={`/${props.dongleId}`}>arrow_back</IconButton>}>
+      <ActivityBar backHref={`/${props.dongleId}`}>
         {startTime()}
-      </TopAppBar>
+      </ActivityBar>
 
       <div class="flex flex-col gap-6 px-4 pb-4">
         <Suspense

--- a/src/pages/dashboard/activities/SettingsActivity.tsx
+++ b/src/pages/dashboard/activities/SettingsActivity.tsx
@@ -5,7 +5,6 @@ import clsx from 'clsx'
 import { getDevice } from '~/api/devices'
 import { cancelSubscription, getStripeCheckout, getStripePortal, getStripeSession, getSubscribeInfo, getSubscriptionStatus } from '~/api/prime'
 import { formatDate } from '~/utils/date'
-import { getDeviceName } from '~/utils/device'
 
 import ButtonBase from '~/components/material/ButtonBase'
 import Button from '~/components/material/Button'

--- a/src/pages/dashboard/activities/SettingsActivity.tsx
+++ b/src/pages/dashboard/activities/SettingsActivity.tsx
@@ -11,9 +11,9 @@ import ButtonBase from '~/components/material/ButtonBase'
 import Button from '~/components/material/Button'
 import CircularProgress from '~/components/material/CircularProgress'
 import Icon from '~/components/material/Icon'
-import IconButton from '~/components/material/IconButton'
-import TopAppBar from '~/components/material/TopAppBar'
 import { createQuery } from '~/utils/createQuery'
+
+import ActivityBar from '../components/ActivityBar'
 
 const useAction = <T,>(action: () => Promise<T>): [() => void, Resource<T>] => {
   const [source, setSource] = createSignal(false)
@@ -350,13 +350,12 @@ const PrimeManage: VoidComponent<{ dongleId: string }> = (props) => {
 }
 
 const SettingsActivity: VoidComponent<PrimeActivityProps> = (props) => {
-  const dongleId = () => props.dongleId
-  const [device] = createResource(dongleId, getDevice)
+  const [device] = createResource(() => props.dongleId, getDevice)
   return (
     <>
-      <TopAppBar leading={<IconButton href={`/${dongleId()}`}>arrow_back</IconButton>}>
+      <ActivityBar backHref={`/${props.dongleId}`}>
         <Show when={device()} keyed>{device => getDeviceName(device)}</Show>
-      </TopAppBar>
+      </ActivityBar>
       <div class="max-w-lg px-4">
         <h2 class="mb-4 text-headline-sm">comma prime</h2>
         <Suspense>

--- a/src/pages/dashboard/activities/SettingsActivity.tsx
+++ b/src/pages/dashboard/activities/SettingsActivity.tsx
@@ -354,7 +354,7 @@ const SettingsActivity: VoidComponent<PrimeActivityProps> = (props) => {
   return (
     <>
       <ActivityBar backHref={`/${props.dongleId}`}>
-        <Show when={device()} keyed>{device => getDeviceName(device)}</Show>
+        Device Settings
       </ActivityBar>
       <div class="max-w-lg px-4">
         <h2 class="mb-4 text-headline-sm">comma prime</h2>

--- a/src/pages/dashboard/components/ActivityBar.tsx
+++ b/src/pages/dashboard/components/ActivityBar.tsx
@@ -8,14 +8,12 @@ interface ActivityBarProps {
 }
 
 const ActivityBar: ParentComponent<ActivityBarProps> = (props) => {
-  return (
-    <TopAppBar
-      leading={<IconButton class="md:hidden" href={props.backHref}>arrow_back</IconButton>}
-      trailing={<IconButton class="hidden md:inline-flex" href={props.backHref}>close</IconButton>}
-    >
-      {props.children}
-    </TopAppBar>
-  )
+  return <TopAppBar
+    leading={<IconButton class="md:hidden" href={props.backHref}>arrow_back</IconButton>}
+    trailing={<IconButton class="hidden md:inline-flex" href={props.backHref}>close</IconButton>}
+  >
+    {props.children}
+  </TopAppBar>
 }
 
 export default ActivityBar

--- a/src/pages/dashboard/components/ActivityBar.tsx
+++ b/src/pages/dashboard/components/ActivityBar.tsx
@@ -1,0 +1,21 @@
+import type { ParentComponent } from 'solid-js'
+
+import IconButton from '~/components/material/IconButton'
+import TopAppBar from '~/components/material/TopAppBar'
+
+interface ActivityBarProps {
+  backHref: string
+}
+
+const ActivityBar: ParentComponent<ActivityBarProps> = (props) => {
+  return (
+    <TopAppBar
+      leading={<IconButton class="md:hidden" href={props.backHref}>arrow_back</IconButton>}
+      trailing={<IconButton class="hidden md:inline-flex" href={props.backHref}>close</IconButton>}
+    >
+      {props.children}
+    </TopAppBar>
+  )
+}
+
+export default ActivityBar


### PR DESCRIPTION
Make use of the space available on desktop to show route list side-by-side with the route video/map/device settings