### PR TITLE
fix(Drawer): prevent scrollbar shifting when zooming out

### DIFF
--- a/src/components/material/Drawer.tsx
+++ b/src/components/material/Drawer.tsx
@@ -33,7 +33,7 @@ const Drawer: ParentComponent<DrawerProps> = (props) => {
   const dimensions = useDimensions()
   const drawerWidth = () => Math.min(dimensions().width - PEEK, 360)
   const modal = () => dimensions().width < 840
-  const contentWidth = () => dimensions().width - (modal() ? 0 : drawerWidth())
+  const contentWidth = () => `calc(100% - ${modal() ? 0 : drawerWidth()}px)`
 
   const [open, setOpen] = createSignal(false)
   const drawerVisible = () => !modal() || open()
@@ -57,7 +57,7 @@ const Drawer: ParentComponent<DrawerProps> = (props) => {
         class="absolute inset-y-0 overflow-y-auto bg-background transition-drawer duration-500"
         style={{
           left: drawerVisible() ? `${drawerWidth()}px` : 0,
-          width: `${contentWidth()}px`,
+          width: contentWidth(),
         }}
       >
         {props.children}


### PR DESCRIPTION
| Current UI | Proposed UI |
|------------|-------------|
| ![chrome-scroll-bug](https://github.com/user-attachments/assets/05c44062-9004-4e42-9618-c0f42b0ad607) | ![chrome-no-shifts](https://github.com/user-attachments/assets/69f37acb-befc-4d79-8c65-0f4ec5e1167d) |

<br>

- Same shifting scrollbar bug as PR #144 
- This fixes the shifting of the scrollbar when zooming out
- Bug shows for Chrome, Firefox and Safari