### PR TITLE
fix: various text wrapping and overflow issues

### DIFF
--- a/src/components/DeviceLocation.tsx
+++ b/src/components/DeviceLocation.tsx
@@ -7,6 +7,8 @@ import Icon from './material/Icon'
 import Button from './material/Button'
 
 import { getDeviceLocation } from '~/api/devices'
+import Card from '~/components/material/Card'
+import IconButton from '~/components/material/IconButton'
 import { getTileUrl } from '~/map'
 import { getFullAddress } from '~/map/geocode'
 
@@ -189,27 +191,25 @@ const DeviceLocation: VoidComponent<DeviceLocationProps> = (props) => {
         </div>
       </Show>
 
-      <div class={clsx(
-        'absolute bottom-0 left-0 z-[9999] w-full p-2 transition-opacity duration-150',
+      <Card class={clsx(
+        'absolute inset-2 top-auto z-[9999] flex !bg-surface-container-high p-4 pt-3 transition-opacity duration-150',
         showSelectedLocation() ? 'opacity-100' : 'pointer-events-none opacity-0',
       )}>
-        <div class="flex w-full gap-4 rounded-lg bg-surface-container-high p-4 shadow-lg">
-          <div class="flex-auto">
-            <h3 class="mb-2 font-bold">{selectedLocation()?.label}</h3>
-            <p class="mb-2 text-sm text-on-surface-variant">{selectedLocation()?.address}</p>
-          </div>
-          <div class="shrink-0 self-end">
-            <Button
-              color="secondary"
-              onClick={() => window.open(`https://www.google.com/maps?q=${selectedLocation()!.lat},${selectedLocation()!.lng}`, '_blank')}
-              trailing={<Icon size="20">open_in_new</Icon>}
-              class="rounded-lg bg-gray-50 px-3 py-2 text-sm font-medium text-black"
-            >
-              Open in Maps
-            </Button>
-          </div>
+        <div class="mb-2 flex flex-row items-center justify-between gap-4">
+          <span class="truncate text-title-md">{selectedLocation()?.label}</span>
+          <IconButton onClick={() => setShowSelectedLocation(false)}>close</IconButton>
         </div>
-      </div>
+        <div class="flex flex-col items-end gap-3 xs:flex-row">
+          <span class="text-body-md text-on-surface-variant">{selectedLocation()?.address}</span>
+          <Button
+            color="secondary"
+            onClick={() => window.open(`https://www.google.com/maps?q=${selectedLocation()!.lat},${selectedLocation()!.lng}`, '_blank')}
+            trailing={<Icon size="20">open_in_new</Icon>}
+          >
+            Open in Maps
+          </Button>
+        </div>
+      </Card>
     </div>
   )
 }

--- a/src/components/DeviceLocation.tsx
+++ b/src/components/DeviceLocation.tsx
@@ -29,6 +29,7 @@ const DeviceLocation: VoidComponent<DeviceLocationProps> = (props) => {
 
   const [map, setMap] = createSignal<L.Map | null>(null)
   const [selectedLocation, setSelectedLocation] = createSignal<Location | null>(null)
+  const [showSelectedLocation, setShowSelectedLocation] = createSignal(false)
   const [userPosition, setUserPosition] = createSignal<GeolocationPosition | null>(null)
   const [deviceLocation] = createResource(
     () => props.dongleId,
@@ -56,7 +57,7 @@ const DeviceLocation: VoidComponent<DeviceLocationProps> = (props) => {
       },
     )
     m.setView(SAN_DIEGO, 10)
-    m.on('click', () => setSelectedLocation(null))
+    m.on('click', () => setShowSelectedLocation(false))
 
     setMap(m)
 
@@ -99,12 +100,12 @@ const DeviceLocation: VoidComponent<DeviceLocationProps> = (props) => {
 
     if (args.userPosition) {
       const { longitude, latitude } = args.userPosition.coords
-      const addr = await getFullAddress([longitude, latitude])
+      const address = await getFullAddress([longitude, latitude])
       const userLoc: Location = {
         lat: latitude,
         lng: longitude,
         label: 'You',
-        address: addr,
+        address,
       }
 
       addMarker(args.map, userLoc, 'person', 'bg-primary')
@@ -140,7 +141,10 @@ const DeviceLocation: VoidComponent<DeviceLocationProps> = (props) => {
 
     L.marker([loc.lat, loc.lng], { icon })
       .addTo(instance)
-      .on('click', () => setSelectedLocation(loc))
+      .on('click', () => {
+        setSelectedLocation(loc)
+        setShowSelectedLocation(true)
+      })
   }
 
   const requestUserLocation = () => {
@@ -157,7 +161,7 @@ const DeviceLocation: VoidComponent<DeviceLocationProps> = (props) => {
     <div class="relative">
       <div ref={mapRef} class="h-[240px] w-full !bg-surface-container-low" />
 
-      <Show when={!userPosition()}>
+      <Show when={!userPosition() && !showSelectedLocation()}>
         <div class="absolute bottom-2 right-2 z-[9999]">
           <Button
             title="Show your current location"
@@ -187,7 +191,7 @@ const DeviceLocation: VoidComponent<DeviceLocationProps> = (props) => {
 
       <div class={clsx(
         'absolute bottom-0 left-0 z-[9999] w-full p-2 transition-opacity duration-150',
-        selectedLocation() ? 'opacity-100' : 'pointer-events-none opacity-0',
+        showSelectedLocation() ? 'opacity-100' : 'pointer-events-none opacity-0',
       )}>
         <div class="flex w-full gap-4 rounded-lg bg-surface-container-high p-4 shadow-lg">
           <div class="flex-auto">

--- a/src/components/material/Card.tsx
+++ b/src/components/material/Card.tsx
@@ -24,21 +24,6 @@ export const CardHeader: VoidComponent<CardHeaderProps> = (props) => {
   )
 }
 
-type CardHeadlineProps = {
-  class?: string
-  title?: string
-  subhead?: string
-}
-
-export const CardHeadline: VoidComponent<CardHeadlineProps> = (props) => {
-  return (
-    <div class={clsx('flex h-12 grow flex-col justify-between', props.class)}>
-      {props.title && <span class="text-body-lg">{props.title}</span>}
-      {props.subhead && <span class="text-body-md text-on-surface-variant">{props.subhead}</span>}
-    </div>
-  )
-}
-
 type CardContentProps = {
   class?: string
 }

--- a/src/components/material/Card.tsx
+++ b/src/components/material/Card.tsx
@@ -1,4 +1,4 @@
-import type { ParentComponent, JSXElement, VoidComponent } from 'solid-js'
+import { type JSXElement, type ParentComponent, Show, type VoidComponent } from 'solid-js'
 import clsx from 'clsx'
 
 import ButtonBase from '~/components/material/ButtonBase'
@@ -77,18 +77,25 @@ type CardProps = {
 }
 
 const Card: ParentComponent<CardProps> = (props) => {
+  const cardStyle = 'flex max-w-md flex-col rounded-lg bg-surface-container-low text-on-surface before:bg-on-surface'
   return (
-    <ButtonBase
-      class={clsx(
-        'state-layer flex max-w-md flex-col rounded-lg bg-surface-container-low text-on-surface before:bg-on-surface',
-        props.class,
-      )}
-      onClick={props.onClick}
-      href={props.href}
-      activeClass={clsx('before:opacity-[.12]', props.activeClass)}
+    <Show
+      when={props.onClick || props.href}
+      fallback={<div class={clsx(cardStyle, props.class)}>{props.children}</div>}
     >
-      {props.children}
-    </ButtonBase>
+      <ButtonBase
+        class={clsx(
+          cardStyle,
+          props.href || props.onClick && 'state-layer',
+          props.class,
+        )}
+        onClick={props.onClick}
+        href={props.href}
+        activeClass={clsx('before:opacity-[.12]', props.activeClass)}
+      >
+        {props.children}
+      </ButtonBase>
+    </Show>
   )
 }
 

--- a/src/components/material/IconButton.tsx
+++ b/src/components/material/IconButton.tsx
@@ -13,19 +13,18 @@ type IconButtonProps = ButtonBaseProps & {
 
 const IconButton: Component<IconButtonProps> = (props) => {
   const size = () => props.size || '24'
-  const buttonSize = () =>
-    ({
-      '20': 'min-w-[28px] min-h-[28px]',
-      '24': 'min-w-[32px] min-h-[32px]',
-      '40': 'min-w-[48px] min-h-[48px]',
-      '48': 'min-w-[56px] min-h-[56px]',
-    }[size()])
+  const buttonSize = () => ({
+    '20': 'w-[28px] h-[28px] min-w-[28px] min-h-[28px]',
+    '24': 'w-[32px] h-[32px] min-w-[32px] min-h-[32px]',
+    '40': 'w-[48px] h-[48px] min-w-[48px] min-h-[48px]',
+    '48': 'w-[56px] h-[56px] min-w-[56px] min-h-[56px]',
+  }[size()])
   const [, rest] = splitProps(props, ['class', 'children', 'filled', 'size'])
   return (
     <ButtonBase
       class={clsx(
         'state-layer inline-flex items-center justify-center rounded-full p-2 before:rounded-full before:bg-on-surface',
-        buttonSize,
+        buttonSize(),
         props.class,
       )}
       {...rest}

--- a/src/components/material/List.tsx
+++ b/src/components/material/List.tsx
@@ -10,8 +10,8 @@ type ListItemContentProps = {
 
 export const ListItemContent: VoidComponent<ListItemContentProps> = (props) => {
   return (
-    <div>
-      <div class="text-body-lg text-on-surface">{props.headline}</div>
+    <div class="min-w-0">
+      <div class="truncate text-body-lg text-on-surface">{props.headline}</div>
       {props.subhead && <div class="text-body-md text-on-surface-variant">{props.subhead}</div>}
     </div>
   )

--- a/src/components/material/TopAppBar.tsx
+++ b/src/components/material/TopAppBar.tsx
@@ -18,7 +18,7 @@ const TopAppBar: ParentComponent<TopAppBarProps> = (props) => {
       )}
     >
       {props.leading}
-      <Dynamic class="grow text-title-lg" component={props.component || 'h2'}>
+      <Dynamic class="grow truncate text-title-lg" component={props.component || 'h2'}>
         {props.children}
       </Dynamic>
       {props.trailing}

--- a/src/pages/dashboard/components/DeviceList.tsx
+++ b/src/pages/dashboard/components/DeviceList.tsx
@@ -31,7 +31,7 @@ const DeviceList: VoidComponent<DeviceListProps> = (props) => {
             <ListItem
               variant="nav"
               leading={<div class={clsx(
-                'm-2 size-2 rounded-full',
+                'm-2 size-2 shrink-0 rounded-full',
                 deviceIsOnline(device) ? 'bg-green-400' : 'bg-gray-400',
               )} />}
               selected={isSelected(device)}


### PR DESCRIPTION
- fixes device list overflow
- fixes text overflow in app bar
- force icons to have correct width and height - don't get squashed when there isn't enough space for neighbouring text
- fix the DeviceLocation card to truncate long device names, wrap text, and cleanup code