### PR TITLE
Fix: update geocoding test to correct address

### DIFF
--- a/src/map/geocode.spec.ts
+++ b/src/map/geocode.spec.ts
@@ -14,7 +14,7 @@ describe('getFullAddress', () => {
   })
 
   test('normal usage', async () => {
-    expect(await getFullAddress([-77.036551, 38.898104])).toBe('1450 Pennsylvania Avenue Northwest, Washington, District of Columbia 20037, United States')
+    expect(await getFullAddress([-77.036551, 38.898104])).toBe('1600 Pennsylvania Avenue Northwest, Washington, District of Columbia 20500, United States')
     expect(await getFullAddress([-0.106640, 51.514209])).toBe('133 Fleet Street, City of London, London, EC4A 2BB, United Kingdom')
     expect(await getFullAddress([-2.076843, 51.894799])).toBe('4 Montpellier Drive, Cheltenham, GL50 1TX, United Kingdom')
   })


### PR DESCRIPTION
## Error
![Screenshot 2025-02-13 at 9 15 28 PM](https://github.com/user-attachments/assets/c49d2330-6b3e-4662-8c9e-c5dc936ed8e5)

- Was getting the above error in PR #164 . Seems like the current address are now wrong because mapbox got more accurate, which then changed to the actual address of the white house. Below is the address of the white house also found [here](https://www.usa.gov/agencies/white-house).
- Got the same error when I did a blank commit in PR #190 
<br>

## White House address
![Screenshot 2025-02-13 at 9 33 49 PM](https://github.com/user-attachments/assets/fdc8c4dd-8151-4213-977d-432a4f9e4b2f)


