### PR TITLE
CI: skip if triggering workflow failed

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -148,7 +148,7 @@ jobs:
 
   update_pr_check:
     needs: preview
-    if: always() && github.event.workflow_run.event == 'pull_request'
+    if: always() && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - name: Update PR check


### PR DESCRIPTION
### Problem:
- When Build workflow fails, Preview workflow still triggers
- `needs.preview.outputs.check_id` is undefined (because preview job couldn't run)
- Results in JavaScript syntax error from: check_run_id: ,
- Ran into this problem wth PR #164 when it didn't pass the test the first time, after I committed the updated white house address, I got the below error from Preview workflow
![Screenshot 2025-02-15 at 1 25 28 PM](https://github.com/user-attachments/assets/62df9a28-830b-4d79-8f4a-3a2528157ed0)


<br><br>

### Solution:
- Add github.event.workflow_run.conclusion == 'success' to skip when triggering workflow failed
- Put success check first for efficient short-circuit
- Code also found in [commai/website repo](https://github.com/commaai/website/blob/master/.github/workflows/preview.yaml#L112)