### PR TITLE
UI: Center copy icon

### DIFF
--- a/src/components/RouteActions.tsx
+++ b/src/components/RouteActions.tsx
@@ -119,9 +119,7 @@ const RouteActions: VoidComponent<RouteActionsProps> = (props) => {
               {currentRouteId().split('/')[1] || ''}
             </span>
           </div>
-          <div class="px-4">
-            <Icon size="24" class={clsx(copied() && 'text-green-300')}>{copied() ? 'check' : 'file_copy'}</Icon>
-          </div>
+          <Icon size="24" class={clsx('px-4', copied() && 'text-green-300')}>{copied() ? 'check' : 'file_copy'}</Icon>
         </button>
       </div>
 

--- a/src/components/RouteActions.tsx
+++ b/src/components/RouteActions.tsx
@@ -119,7 +119,9 @@ const RouteActions: VoidComponent<RouteActionsProps> = (props) => {
               {currentRouteId().split('/')[1] || ''}
             </span>
           </div>
-          <Icon size="24" class={clsx('ml-2', copied() && 'text-green-300')}>{copied() ? 'check' : 'file_copy'}</Icon>
+          <div class="px-4">
+            <Icon size="24" class={clsx(copied() && 'text-green-300')}>{copied() ? 'check' : 'file_copy'}</Icon>
+          </div>
         </button>
       </div>
 


### PR DESCRIPTION
- Copy icon is not centered with the below toggles
- Adjusted spacing to still trigger the words breaking into the new line while keeping icon centered above the toggles

---

### Current UI
![not-centered-icon](https://github.com/user-attachments/assets/58f555ef-bc36-470d-9894-f3cc45ae1fe5)

<br>

### Proposed UI

https://github.com/user-attachments/assets/2bfdbda5-3a98-410b-90df-d2bd1e50c43b

