### PR TITLE
Added start time in video player

### DIFF
--- a/src/components/RouteVideoPlayer.tsx
+++ b/src/components/RouteVideoPlayer.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createResource, onCleanup, onMount, type VoidComponent } from 'solid-js'
+import { Accessor, createEffect, createResource, onCleanup, onMount, type VoidComponent } from 'solid-js'
 import clsx from 'clsx'
 import Hls from 'hls.js/dist/hls.light.mjs'
 
@@ -7,6 +7,7 @@ import { getQCameraStreamUrl } from '~/api/route'
 type RouteVideoPlayerProps = {
   class?: string
   routeName: string
+  seekTime: number
   onProgress?: (seekTime: number) => void
   ref?: (el: HTMLVideoElement) => void
 }
@@ -19,6 +20,7 @@ const RouteVideoPlayer: VoidComponent<RouteVideoPlayerProps> = (props) => {
     const timeUpdate = () => props.onProgress?.(video.currentTime)
     video.addEventListener('timeupdate', timeUpdate)
     onCleanup(() => video.removeEventListener('timeupdate', timeUpdate))
+    video.currentTime = props.seekTime
     props.ref?.(video)
   })
 

--- a/src/components/RouteVideoPlayer.tsx
+++ b/src/components/RouteVideoPlayer.tsx
@@ -1,4 +1,4 @@
-import { Accessor, createEffect, createResource, onCleanup, onMount, type VoidComponent } from 'solid-js'
+import { createEffect, createResource, onCleanup, onMount, type VoidComponent } from 'solid-js'
 import clsx from 'clsx'
 import Hls from 'hls.js/dist/hls.light.mjs'
 

--- a/src/components/RouteVideoPlayer.tsx
+++ b/src/components/RouteVideoPlayer.tsx
@@ -7,7 +7,7 @@ import { getQCameraStreamUrl } from '~/api/route'
 type RouteVideoPlayerProps = {
   class?: string
   routeName: string
-  seekTime: number
+  startTime: number
   onProgress?: (seekTime: number) => void
   ref?: (el: HTMLVideoElement) => void
 }
@@ -20,7 +20,7 @@ const RouteVideoPlayer: VoidComponent<RouteVideoPlayerProps> = (props) => {
     const timeUpdate = () => props.onProgress?.(video.currentTime)
     video.addEventListener('timeupdate', timeUpdate)
     onCleanup(() => video.removeEventListener('timeupdate', timeUpdate))
-    video.currentTime = props.seekTime
+    video.currentTime = props.startTime
     props.ref?.(video)
   })
 

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -82,6 +82,7 @@ const Dashboard: Component<RouteSectionProps> = () => {
   const pathParts = () => location.pathname.split('/').slice(1).filter(Boolean)
   const dongleId = () => pathParts()[0]
   const dateStr = () => pathParts()[1]
+  const startTime = () => pathParts()[2] ? Number(pathParts()[2]) : 0
 
   const pairToken = () => !!location.query.pair
 
@@ -119,7 +120,7 @@ const Dashboard: Component<RouteSectionProps> = () => {
                 <SettingsActivity dongleId={id} />
               </Match>
               <Match when={dateStr()} keyed>
-                {(date) => <RouteActivity dongleId={id} dateStr={date} />}
+                {(date) => <RouteActivity dongleId={id} dateStr={date} startTime={startTime()} />}
               </Match>
             </Switch>}
             paneTwoContent={!!dateStr()}

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -1,5 +1,4 @@
 import {
-  createEffect,
   createResource,
   createSignal,
   lazy,

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -49,7 +49,7 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
             <div class="skeleton-loader aspect-[241/151] rounded-lg bg-surface-container-low" />
           }
         >
-          <RouteVideoPlayer ref={setVideoRef} routeName={routeName()} seekTime={seekTime()} onProgress={setSeekTime} />
+          <RouteVideoPlayer ref={setVideoRef} routeName={routeName()} startTime={seekTime()} onProgress={setSeekTime} />
         </Suspense>
 
         <div class="flex flex-col gap-2">

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -1,4 +1,5 @@
 import {
+  createEffect,
   createResource,
   createSignal,
   lazy,
@@ -20,10 +21,11 @@ const RouteVideoPlayer = lazy(() => import('~/components/RouteVideoPlayer'))
 type RouteActivityProps = {
   dongleId: string
   dateStr: string
+  startTime: number
 }
 
 const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
-  const [seekTime, setSeekTime] = createSignal(0)
+  const [seekTime, setSeekTime] = createSignal(props.startTime)
   const [videoRef, setVideoRef] = createSignal<HTMLVideoElement>()
 
   const routeName = () => `${props.dongleId}|${props.dateStr}`
@@ -47,7 +49,7 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
             <div class="skeleton-loader aspect-[241/151] rounded-lg bg-surface-container-low" />
           }
         >
-          <RouteVideoPlayer ref={setVideoRef} routeName={routeName()} onProgress={setSeekTime} />
+          <RouteVideoPlayer ref={setVideoRef} routeName={routeName()} seekTime={seekTime()} onProgress={setSeekTime} />
         </Suspense>
 
         <div class="flex flex-col gap-2">


### PR DESCRIPTION
Added a quick enhancement to get the start time from URL. The time is in seconds. Issue: #194 

For the "zoom" into part, I am thinking we could do a window that will be on the timeline bar and the rest of the bar grayed out while listening for the current time. If it reaches the end time, we could put it back to the start time of the window. 