### PR TITLE
Cached playwright in test job.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           path: |
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}\
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/bun.lockb') }}\
 
       - run: bun install --frozen-lockfile
       - run: bun playwright install

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           path: |
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/bun.lockb') }}\
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/bun.lockb') }}
 
       - run: bun install --frozen-lockfile
       - run: bun playwright install

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,8 +15,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
 
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}\
+
       - run: bun install --frozen-lockfile
       - run: bun playwright install
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
       - run: bun run lint --reporter=github
       - run: bun run test
       - run: bun lines

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
-
       - uses: actions/cache@v4
         id: playwright-cache
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
+
       - uses: actions/cache@v4
         id: playwright-cache
         with:


### PR DESCRIPTION
Job now uses cached playwright files to run test. Key is generated from the hash of `bun.lockb` file.  Issue: #181 

I am not sure if this approach is better than directly having key as the playwright version contained in `package.json`. Any changes in the lock file will trigger `bun playwright install` even if there are no playwright specific changes in that file.

build / test reduced from 37secs ----> 19secs