### PR TITLE
refactor: retrieve routes using `solid-query`

### DIFF
--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -4,10 +4,30 @@ import { configure, render, waitFor } from '@solidjs/testing-library'
 import { clearAccessToken, setAccessToken } from '~/api/auth/client'
 import * as Demo from '~/api/auth/demo'
 import { AppLayout, Routes } from './App'
+import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
+import { createMemoryHistory, MemoryRouter } from '@solidjs/router'
 
 const DEMO_LOG_ID = '000000dd--455f14369d'
 
-const renderApp = (location: string) => render(() => <Routes />, { location, wrapper: AppLayout })
+const createTestQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+const renderApp = (location: string) => {
+  // @solidjs/testing-library doesn't handle the QueryClientProvider wrapping, we need to own it here
+  const history = createMemoryHistory()
+  history.set({ value: location, scroll: false, replace: true })
+  return render(
+    () => (
+      <QueryClientProvider client={createTestQueryClient()}>
+        <MemoryRouter history={history}>
+          <Routes />
+        </MemoryRouter>
+      </QueryClientProvider>
+    ),
+    {
+      wrapper: AppLayout,
+    },
+  )
+}
 
 beforeAll(() => configure({ asyncUtilTimeout: 3000 }))
 beforeEach(() => clearAccessToken())

--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -15,7 +15,7 @@ const createTestQueryClient = () => new QueryClient({ defaultOptions: { queries:
 const TestApp: VoidComponent<{ location: string }> = (props) => {
   // the Router renders the component defined in each Route. we need to wrap the QueryClientProvider
   // around the Router so that the QueryClient is available to the Route components. so, create
-  // our own memory wrapper instead of the internal @solidjs/testing-library Router wrapper
+  // our own MemoryRouter instead of the internal @solidjs/testing-library wrapper
   const history = createMemoryHistory()
   history.set({ value: props.location, scroll: false, replace: true })
 

--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -13,7 +13,8 @@ const DEMO_LOG_ID = '000000dd--455f14369d'
 const createTestQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
 const TestApp: VoidComponent<{ location: string }> = (props) => {
-  // @solidjs/testing-library mounts the component inside the Router; we need to wrap the Provider around the Router
+  // @solidjs/testing-library renders the component inside the Router. we need to wrap the Provider around the Router
+  // so that the QueryClient is available to all tests
   const history = createMemoryHistory()
   history.set({ value: props.location, scroll: false, replace: true })
 

--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -1,12 +1,12 @@
 import { VoidComponent } from 'solid-js'
 import { beforeAll, beforeEach, describe, expect, test } from 'vitest'
 import { configure, render, waitFor } from '@solidjs/testing-library'
+import { createMemoryHistory, MemoryRouter } from '@solidjs/router'
+import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
 
 import { clearAccessToken, setAccessToken } from '~/api/auth/client'
 import * as Demo from '~/api/auth/demo'
 import { AppLayout, Routes } from './App'
-import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
-import { createMemoryHistory, MemoryRouter } from '@solidjs/router'
 
 const DEMO_LOG_ID = '000000dd--455f14369d'
 

--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -13,8 +13,9 @@ const DEMO_LOG_ID = '000000dd--455f14369d'
 const createTestQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
 const TestApp: VoidComponent<{ location: string }> = (props) => {
-  // @solidjs/testing-library renders the component inside the Router. we need to wrap the Provider around the Router
-  // so that the QueryClient is available to all tests
+  // the Router renders the component defined in each Route. we need to wrap the QueryClientProvider
+  // around the Router so that the QueryClient is available to the Route components. so, create
+  // our own memory wrapper instead of the internal @solidjs/testing-library Router wrapper
   const history = createMemoryHistory()
   history.set({ value: props.location, scroll: false, replace: true })
 

--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -13,7 +13,7 @@ const DEMO_LOG_ID = '000000dd--455f14369d'
 const createTestQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
 const TestApp: VoidComponent<{ location: string }> = (props) => {
-  // @solidjs/testing-library doesn't handle the QueryClientProvider wrapping, we need to own it here
+  // @solidjs/testing-library mounts the component inside the Router; we need to wrap the Provider around the Router
   const history = createMemoryHistory()
   history.set({ value: props.location, scroll: false, replace: true })
 

--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -1,3 +1,4 @@
+import { VoidComponent } from 'solid-js'
 import { beforeAll, beforeEach, describe, expect, test } from 'vitest'
 import { configure, render, waitFor } from '@solidjs/testing-library'
 
@@ -11,23 +12,23 @@ const DEMO_LOG_ID = '000000dd--455f14369d'
 
 const createTestQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
-const renderApp = (location: string) => {
+const TestApp: VoidComponent<{ location: string }> = (props) => {
   // @solidjs/testing-library doesn't handle the QueryClientProvider wrapping, we need to own it here
   const history = createMemoryHistory()
-  history.set({ value: location, scroll: false, replace: true })
-  return render(
-    () => (
-      <QueryClientProvider client={createTestQueryClient()}>
-        <MemoryRouter history={history}>
+  history.set({ value: props.location, scroll: false, replace: true })
+
+  return (
+    <QueryClientProvider client={createTestQueryClient()}>
+      <MemoryRouter history={history}>
+        <AppLayout>
           <Routes />
-        </MemoryRouter>
-      </QueryClientProvider>
-    ),
-    {
-      wrapper: AppLayout,
-    },
+        </AppLayout>
+      </MemoryRouter>
+    </QueryClientProvider>
   )
 }
+
+const renderApp = (location: string) => render(() => <TestApp location={location} />)
 
 beforeAll(() => configure({ asyncUtilTimeout: 3000 }))
 beforeEach(() => clearAccessToken())

--- a/src/api/query-client.ts
+++ b/src/api/query-client.ts
@@ -9,7 +9,7 @@ export const getAppQueryClient = () => {
 
   queryClient.setQueryDefaults(uploadQueue.online(), pollingConfig)
   queryClient.setQueryDefaults(uploadQueue.offline(), pollingConfig)
-  queryClient.setQueryDefaults(routes.route(), { refetchOnMount: false })
+  queryClient.setQueryDefaults(routes.route, { refetchOnMount: false })
 
   return queryClient
 }

--- a/src/api/query-client.ts
+++ b/src/api/query-client.ts
@@ -2,11 +2,6 @@ import { QueryClient } from '@tanstack/solid-query'
 import { queries as uploadQueue } from '~/components/UploadQueue'
 import { queries as routes } from '~/pages/dashboard/activities/RouteActivity'
 
-const refreshAfterMs = (refreshAfterMs: number) => ({
-  staleTime: refreshAfterMs,
-  refetchOnMount: false,
-  refetchOnWindowFocus: false,
-})
 const pollingConfig = { retry: false, refetchInterval: 1000 }
 
 export const getAppQueryClient = () => {
@@ -14,7 +9,7 @@ export const getAppQueryClient = () => {
 
   queryClient.setQueryDefaults(uploadQueue.online(), pollingConfig)
   queryClient.setQueryDefaults(uploadQueue.offline(), pollingConfig)
-  queryClient.setQueryDefaults(routes.route(), refreshAfterMs(1000 * 60 * 60)) // 1 hour
+  queryClient.setQueryDefaults(routes.route(), { refetchOnMount: false, refetchOnWindowFocus: false })
 
   return queryClient
 }

--- a/src/api/query-client.ts
+++ b/src/api/query-client.ts
@@ -9,7 +9,7 @@ export const getAppQueryClient = () => {
 
   queryClient.setQueryDefaults(uploadQueue.online(), pollingConfig)
   queryClient.setQueryDefaults(uploadQueue.offline(), pollingConfig)
-  queryClient.setQueryDefaults(routes.route(), { refetchOnMount: false, refetchOnWindowFocus: false })
+  queryClient.setQueryDefaults(routes.route(), { refetchOnMount: false })
 
   return queryClient
 }

--- a/src/api/query-client.ts
+++ b/src/api/query-client.ts
@@ -1,6 +1,6 @@
 import { QueryClient } from '@tanstack/solid-query'
 import { queries as uploadQueue } from '~/components/UploadQueue'
-import { queries as route } from '~/pages/dashboard/activities/RouteActivity'
+import { queries as routes } from '~/pages/dashboard/activities/RouteActivity'
 
 const dontRefetchOften = {
   staleTime: 1000 * 60 * 60, // 1 hour
@@ -15,7 +15,7 @@ export const getAppQueryClient = () => {
 
   queryClient.setQueryDefaults(uploadQueue.online(), pollingConfig)
   queryClient.setQueryDefaults(uploadQueue.offline(), pollingConfig)
-  queryClient.setQueryDefaults(route.prefix, { ...dontRefetchOften, ...useSuspense })
+  queryClient.setQueryDefaults(routes.route(), { ...dontRefetchOften, ...useSuspense })
 
   return queryClient
 }

--- a/src/api/query-client.ts
+++ b/src/api/query-client.ts
@@ -1,13 +1,21 @@
 import { QueryClient } from '@tanstack/solid-query'
 import { queries as uploadQueue } from '~/components/UploadQueue'
+import { queries as route } from '~/pages/dashboard/activities/RouteActivity'
 
+const dontRefetchOften = {
+  staleTime: 1000 * 60 * 60, // 1 hour
+  refetchOnMount: false,
+  refetchOnWindowFocus: false,
+}
 const pollingConfig = { retry: false, refetchInterval: 1000 }
+const useSuspense = { throwOnError: true }
 
 export const getAppQueryClient = () => {
   const queryClient = new QueryClient()
 
   queryClient.setQueryDefaults(uploadQueue.online(), pollingConfig)
   queryClient.setQueryDefaults(uploadQueue.offline(), pollingConfig)
+  queryClient.setQueryDefaults(route.prefix, { ...dontRefetchOften, ...useSuspense })
 
   return queryClient
 }

--- a/src/api/query-client.ts
+++ b/src/api/query-client.ts
@@ -2,20 +2,19 @@ import { QueryClient } from '@tanstack/solid-query'
 import { queries as uploadQueue } from '~/components/UploadQueue'
 import { queries as routes } from '~/pages/dashboard/activities/RouteActivity'
 
-const dontRefetchOften = {
-  staleTime: 1000 * 60 * 60, // 1 hour
+const refreshAfterMs = (refreshAfterMs: number) => ({
+  staleTime: refreshAfterMs,
   refetchOnMount: false,
   refetchOnWindowFocus: false,
-}
+})
 const pollingConfig = { retry: false, refetchInterval: 1000 }
-const useSuspense = { throwOnError: true }
 
 export const getAppQueryClient = () => {
   const queryClient = new QueryClient()
 
   queryClient.setQueryDefaults(uploadQueue.online(), pollingConfig)
   queryClient.setQueryDefaults(uploadQueue.offline(), pollingConfig)
-  queryClient.setQueryDefaults(routes.route(), { ...dontRefetchOften, ...useSuspense })
+  queryClient.setQueryDefaults(routes.route(), refreshAfterMs(1000 * 60 * 60)) // 1 hour
 
   return queryClient
 }

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -36,12 +36,13 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
   const [videoRef, setVideoRef] = createSignal<HTMLVideoElement>()
 
   const routeName = () => `${props.dongleId}|${props.dateStr}`
-  const route = createQuery(() => queries.getRoute(routeName()))
-  const [startTime] = createResource(route, (route) => dayjs(route.data?.start_time)?.format('dddd, MMM D, YYYY'))
+  const routeQuery = createQuery(() => queries.getRoute(routeName()))
+  const route = () => routeQuery.data
+  const [startTime] = createResource(route, (route) => dayjs(route?.start_time)?.format('dddd, MMM D, YYYY'))
 
   const selection = () => ({ startTime: props.startTime, endTime: props.endTime })
 
-  const [statistics] = createResource(route.data, getRouteStatistics)
+  const [statistics] = createResource(route(), getRouteStatistics)
 
   const onTimelineChange = (newTime: number) => {
     const video = videoRef()
@@ -87,16 +88,16 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
         <div class="flex flex-col gap-2">
           <span class="text-label-md uppercase">Route Info</span>
           <div class="flex flex-col rounded-md overflow-hidden bg-surface-container">
-            <RouteStatisticsBar class="p-5" route={route.data} statistics={statistics} />
+            <RouteStatisticsBar class="p-5" route={route()} statistics={statistics} />
 
-            <RouteActions routeName={routeName()} route={route.data} />
+            <RouteActions routeName={routeName()} route={route()} />
           </div>
         </div>
 
         <div class="flex flex-col gap-2">
           <span class="text-label-md uppercase">Upload Files</span>
           <div class="flex flex-col rounded-md overflow-hidden bg-surface-container">
-            <RouteUploadButtons route={route.data} />
+            <RouteUploadButtons route={route()} />
           </div>
         </div>
 
@@ -104,7 +105,7 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
           <span class="text-label-md uppercase">Route Map</span>
           <div class="aspect-square overflow-hidden rounded-lg">
             <Suspense fallback={<div class="h-full w-full skeleton-loader bg-surface-container" />}>
-              <RouteStaticMap route={route.data} />
+              <RouteStaticMap route={route()} />
             </Suspense>
           </div>
         </div>

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -27,8 +27,8 @@ type RouteActivityProps = {
 
 export const queries = {
   prefix: ['route'],
-  route: () => queries.prefix,
-  forRouteName: (routeName: string) => [queries.route(), routeName],
+  route: () => [...queries.prefix],
+  forRouteName: (routeName: string) => [...queries.route(), routeName],
   getRoute: (routeName: string) => queryOptions({ queryKey: queries.forRouteName(routeName), queryFn: () => getRoute(routeName) }),
 }
 

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -26,9 +26,8 @@ type RouteActivityProps = {
 }
 
 export const queries = {
-  prefix: ['route'],
-  route: () => queries.prefix,
-  forRouteName: (routeName: string) => [...queries.route(), routeName],
+  route: ['route'],
+  forRouteName: (routeName: string) => [...queries.route, routeName],
   getRoute: (routeName: string) => queryOptions({ queryKey: queries.forRouteName(routeName), queryFn: () => getRoute(routeName) }),
 }
 

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -27,8 +27,8 @@ type RouteActivityProps = {
 
 export const queries = {
   route: ['route'],
-  forRouteName: (routeName: string) => [...queries.route, routeName],
-  getRoute: (routeName: string) => queryOptions({ queryKey: queries.forRouteName(routeName), queryFn: () => getRoute(routeName) }),
+  forRoute: (routeName: string) => [...queries.route, routeName],
+  getRoute: (routeName: string) => queryOptions({ queryKey: queries.forRoute(routeName), queryFn: () => getRoute(routeName) }),
 }
 
 const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -27,7 +27,7 @@ type RouteActivityProps = {
 
 export const queries = {
   prefix: ['route'],
-  route: () => [...queries.prefix],
+  route: () => queries.prefix,
   forRouteName: (routeName: string) => [...queries.route(), routeName],
   getRoute: (routeName: string) => queryOptions({ queryKey: queries.forRouteName(routeName), queryFn: () => getRoute(routeName) }),
 }

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -150,7 +150,7 @@ const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
                 {(route) => {
                   const firstHeader = prevDayHeader === null
                   const dayHeader = getDayHeader(route)
-                  queryClient.setQueryData(queries.forRouteName(route.fullname), route)
+                  queryClient.setQueryData(queries.forRoute(route.fullname), route)
                   return (
                     <>
                       <Show when={dayHeader}>

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -13,6 +13,8 @@ import RouteStatisticsBar from '~/components/RouteStatisticsBar'
 import { getPlaceName } from '~/map/geocode'
 import type { Route } from '~/api/types'
 import { dateTimeToColorBetween } from '~/utils/format'
+import { useQueryClient } from '@tanstack/solid-query'
+import { queries } from '../activities/RouteActivity'
 
 interface RouteCardProps {
   route: Route
@@ -79,6 +81,7 @@ const Sentinel = (props: { onTrigger: () => void }) => {
 const PAGE_SIZE = 10
 
 const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
+  const queryClient = useQueryClient()
   const endpoint = () => `/v1/devices/${props.dongleId}/routes?limit=${PAGE_SIZE}`
   const getKey = (previousPageData?: Route[]): string | undefined => {
     if (!previousPageData) return endpoint()
@@ -147,6 +150,7 @@ const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
                 {(route) => {
                   const firstHeader = prevDayHeader === null
                   const dayHeader = getDayHeader(route)
+                  queryClient.setQueryData(queries.forRouteName(route.fullname), route)
                   return (
                     <>
                       <Show when={dayHeader}>

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -2,6 +2,7 @@ import { createEffect, createResource, createSignal, For, Index, onCleanup, onMo
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc.js'
 import timezone from 'dayjs/plugin/timezone.js'
+import { useQueryClient } from '@tanstack/solid-query'
 dayjs.extend(utc)
 dayjs.extend(timezone)
 
@@ -13,7 +14,6 @@ import RouteStatisticsBar from '~/components/RouteStatisticsBar'
 import { getPlaceName } from '~/map/geocode'
 import type { Route } from '~/api/types'
 import { dateTimeToColorBetween } from '~/utils/format'
-import { useQueryClient } from '@tanstack/solid-query'
 import { queries } from '../activities/RouteActivity'
 
 interface RouteCardProps {

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -12,9 +12,9 @@ import Card, { CardContent, CardHeader } from '~/components/material/Card'
 import Icon from '~/components/material/Icon'
 import RouteStatisticsBar from '~/components/RouteStatisticsBar'
 import { getPlaceName } from '~/map/geocode'
+import { queries } from '~/pages/dashboard/activities/RouteActivity'
 import type { Route } from '~/api/types'
 import { dateTimeToColorBetween } from '~/utils/format'
-import { queries } from '../activities/RouteActivity'
 
 interface RouteCardProps {
   route: Route


### PR DESCRIPTION
here's another simple way to dedupe all route retrievals. when we've fetched a page, store the route in the tanstack query cache, and fetch the route in the `RouteActivity` using tanstack. this solves two major things:

1. Suspense behaves exactly as before (`routes.data` will only trigger suspense if the data wasn't previously recorded). see demo video and test yourself
2. handles navigating to a route directly smoothly. the data isn't in the cache yet (maybe RouteList isn't populated), but it still fetches w/o any special handling, and Suspense is triggered for route metadata like stats in `RouteActivity`

i think introduction of `solid-query` at this point is going to help solve the remaining performance requirements we have, like deduping requests and *eventually* introducing metadata caching like old connect. but before that, no unnecessary requests!

looking for feedback and opinions on the approach

https://github.com/user-attachments/assets/0c59ca45-b499-4115-99e6-349a58778f1c

