### PR TITLE
demo(speed): tanstack in critical path

### DIFF
--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -4,10 +4,30 @@ import { configure, render, waitFor } from '@solidjs/testing-library'
 import { clearAccessToken, setAccessToken } from '~/api/auth/client'
 import * as Demo from '~/api/auth/demo'
 import { AppLayout, Routes } from './App'
+import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
+import { createMemoryHistory, MemoryRouter } from '@solidjs/router'
 
 const DEMO_LOG_ID = '000000dd--455f14369d'
 
-const renderApp = (location: string) => render(() => <Routes />, { location, wrapper: AppLayout })
+const createTestQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+const renderApp = (location: string) => {
+  // @solidjs/testing-library doesn't handle the QueryClientProvider wrapping, we need to own it here
+  const history = createMemoryHistory()
+  history.set({ value: location, scroll: false, replace: true })
+  return render(
+    () => (
+      <QueryClientProvider client={createTestQueryClient()}>
+        <MemoryRouter history={history}>
+          <Routes />
+        </MemoryRouter>
+      </QueryClientProvider>
+    ),
+    {
+      wrapper: AppLayout,
+    },
+  )
+}
 
 beforeAll(() => configure({ asyncUtilTimeout: 3000 }))
 beforeEach(() => clearAccessToken())

--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -15,7 +15,7 @@ const createTestQueryClient = () => new QueryClient({ defaultOptions: { queries:
 const TestApp: VoidComponent<{ location: string }> = (props) => {
   // the Router renders the component defined in each Route. we need to wrap the QueryClientProvider
   // around the Router so that the QueryClient is available to the Route components. so, create
-  // our own memory wrapper instead of the internal @solidjs/testing-library Router wrapper
+  // our own MemoryRouter instead of the internal @solidjs/testing-library wrapper
   const history = createMemoryHistory()
   history.set({ value: props.location, scroll: false, replace: true })
 

--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -13,7 +13,8 @@ const DEMO_LOG_ID = '000000dd--455f14369d'
 const createTestQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
 const TestApp: VoidComponent<{ location: string }> = (props) => {
-  // @solidjs/testing-library mounts the component inside the Router; we need to wrap the Provider around the Router
+  // @solidjs/testing-library renders the component inside the Router. we need to wrap the Provider around the Router
+  // so that the QueryClient is available to all tests
   const history = createMemoryHistory()
   history.set({ value: props.location, scroll: false, replace: true })
 

--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -1,12 +1,12 @@
 import { VoidComponent } from 'solid-js'
 import { beforeAll, beforeEach, describe, expect, test } from 'vitest'
 import { configure, render, waitFor } from '@solidjs/testing-library'
+import { createMemoryHistory, MemoryRouter } from '@solidjs/router'
+import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
 
 import { clearAccessToken, setAccessToken } from '~/api/auth/client'
 import * as Demo from '~/api/auth/demo'
 import { AppLayout, Routes } from './App'
-import { QueryClient, QueryClientProvider } from '@tanstack/solid-query'
-import { createMemoryHistory, MemoryRouter } from '@solidjs/router'
 
 const DEMO_LOG_ID = '000000dd--455f14369d'
 

--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -13,8 +13,9 @@ const DEMO_LOG_ID = '000000dd--455f14369d'
 const createTestQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
 const TestApp: VoidComponent<{ location: string }> = (props) => {
-  // @solidjs/testing-library renders the component inside the Router. we need to wrap the Provider around the Router
-  // so that the QueryClient is available to all tests
+  // the Router renders the component defined in each Route. we need to wrap the QueryClientProvider
+  // around the Router so that the QueryClient is available to the Route components. so, create
+  // our own memory wrapper instead of the internal @solidjs/testing-library Router wrapper
   const history = createMemoryHistory()
   history.set({ value: props.location, scroll: false, replace: true })
 

--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -13,7 +13,7 @@ const DEMO_LOG_ID = '000000dd--455f14369d'
 const createTestQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
 const TestApp: VoidComponent<{ location: string }> = (props) => {
-  // @solidjs/testing-library doesn't handle the QueryClientProvider wrapping, we need to own it here
+  // @solidjs/testing-library mounts the component inside the Router; we need to wrap the Provider around the Router
   const history = createMemoryHistory()
   history.set({ value: props.location, scroll: false, replace: true })
 

--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -1,3 +1,4 @@
+import { VoidComponent } from 'solid-js'
 import { beforeAll, beforeEach, describe, expect, test } from 'vitest'
 import { configure, render, waitFor } from '@solidjs/testing-library'
 
@@ -11,23 +12,23 @@ const DEMO_LOG_ID = '000000dd--455f14369d'
 
 const createTestQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
-const renderApp = (location: string) => {
+const TestApp: VoidComponent<{ location: string }> = (props) => {
   // @solidjs/testing-library doesn't handle the QueryClientProvider wrapping, we need to own it here
   const history = createMemoryHistory()
-  history.set({ value: location, scroll: false, replace: true })
-  return render(
-    () => (
-      <QueryClientProvider client={createTestQueryClient()}>
-        <MemoryRouter history={history}>
+  history.set({ value: props.location, scroll: false, replace: true })
+
+  return (
+    <QueryClientProvider client={createTestQueryClient()}>
+      <MemoryRouter history={history}>
+        <AppLayout>
           <Routes />
-        </MemoryRouter>
-      </QueryClientProvider>
-    ),
-    {
-      wrapper: AppLayout,
-    },
+        </AppLayout>
+      </MemoryRouter>
+    </QueryClientProvider>
   )
 }
+
+const renderApp = (location: string) => render(() => <TestApp location={location} />)
 
 beforeAll(() => configure({ asyncUtilTimeout: 3000 }))
 beforeEach(() => clearAccessToken())

--- a/src/api/query-client.ts
+++ b/src/api/query-client.ts
@@ -9,7 +9,7 @@ export const getAppQueryClient = () => {
 
   queryClient.setQueryDefaults(uploadQueue.online(), pollingConfig)
   queryClient.setQueryDefaults(uploadQueue.offline(), pollingConfig)
-  queryClient.setQueryDefaults(routes.route(), { refetchOnMount: false })
+  queryClient.setQueryDefaults(routes.route, { refetchOnMount: false })
 
   return queryClient
 }

--- a/src/api/query-client.ts
+++ b/src/api/query-client.ts
@@ -2,11 +2,6 @@ import { QueryClient } from '@tanstack/solid-query'
 import { queries as uploadQueue } from '~/components/UploadQueue'
 import { queries as routes } from '~/pages/dashboard/activities/RouteActivity'
 
-const refreshAfterMs = (refreshAfterMs: number) => ({
-  staleTime: refreshAfterMs,
-  refetchOnMount: false,
-  refetchOnWindowFocus: false,
-})
 const pollingConfig = { retry: false, refetchInterval: 1000 }
 
 export const getAppQueryClient = () => {
@@ -14,7 +9,7 @@ export const getAppQueryClient = () => {
 
   queryClient.setQueryDefaults(uploadQueue.online(), pollingConfig)
   queryClient.setQueryDefaults(uploadQueue.offline(), pollingConfig)
-  queryClient.setQueryDefaults(routes.route(), refreshAfterMs(1000 * 60 * 60)) // 1 hour
+  queryClient.setQueryDefaults(routes.route(), { refetchOnMount: false, refetchOnWindowFocus: false })
 
   return queryClient
 }

--- a/src/api/query-client.ts
+++ b/src/api/query-client.ts
@@ -9,7 +9,7 @@ export const getAppQueryClient = () => {
 
   queryClient.setQueryDefaults(uploadQueue.online(), pollingConfig)
   queryClient.setQueryDefaults(uploadQueue.offline(), pollingConfig)
-  queryClient.setQueryDefaults(routes.route(), { refetchOnMount: false, refetchOnWindowFocus: false })
+  queryClient.setQueryDefaults(routes.route(), { refetchOnMount: false })
 
   return queryClient
 }

--- a/src/api/query-client.ts
+++ b/src/api/query-client.ts
@@ -1,6 +1,7 @@
 import { QueryClient } from '@tanstack/solid-query'
 import { queries as uploadQueue } from '~/components/UploadQueue'
 import { queries as routes } from '~/pages/dashboard/activities/RouteActivity'
+import { queries as devices } from '~/pages/dashboard/activities/DeviceActivity'
 
 const pollingConfig = { retry: false, refetchInterval: 1000 }
 
@@ -10,6 +11,10 @@ export const getAppQueryClient = () => {
   queryClient.setQueryDefaults(uploadQueue.online(), pollingConfig)
   queryClient.setQueryDefaults(uploadQueue.offline(), pollingConfig)
   queryClient.setQueryDefaults(routes.route, { refetchOnMount: false })
+  queryClient.setQueryDefaults(routes.statistics(), { refetchOnMount: false })
+  queryClient.setQueryDefaults(routes.location(), { refetchOnMount: false })
+  queryClient.setQueryDefaults(devices.device, { refetchOnMount: false })
+  queryClient.setQueryDefaults(devices.allDevices(), { refetchOnMount: false })
 
   return queryClient
 }

--- a/src/api/query-client.ts
+++ b/src/api/query-client.ts
@@ -1,6 +1,6 @@
 import { QueryClient } from '@tanstack/solid-query'
 import { queries as uploadQueue } from '~/components/UploadQueue'
-import { queries as route } from '~/pages/dashboard/activities/RouteActivity'
+import { queries as routes } from '~/pages/dashboard/activities/RouteActivity'
 
 const dontRefetchOften = {
   staleTime: 1000 * 60 * 60, // 1 hour
@@ -15,7 +15,7 @@ export const getAppQueryClient = () => {
 
   queryClient.setQueryDefaults(uploadQueue.online(), pollingConfig)
   queryClient.setQueryDefaults(uploadQueue.offline(), pollingConfig)
-  queryClient.setQueryDefaults(route.prefix, { ...dontRefetchOften, ...useSuspense })
+  queryClient.setQueryDefaults(routes.route(), { ...dontRefetchOften, ...useSuspense })
 
   return queryClient
 }

--- a/src/api/query-client.ts
+++ b/src/api/query-client.ts
@@ -1,13 +1,21 @@
 import { QueryClient } from '@tanstack/solid-query'
 import { queries as uploadQueue } from '~/components/UploadQueue'
+import { queries as route } from '~/pages/dashboard/activities/RouteActivity'
 
+const dontRefetchOften = {
+  staleTime: 1000 * 60 * 60, // 1 hour
+  refetchOnMount: false,
+  refetchOnWindowFocus: false,
+}
 const pollingConfig = { retry: false, refetchInterval: 1000 }
+const useSuspense = { throwOnError: true }
 
 export const getAppQueryClient = () => {
   const queryClient = new QueryClient()
 
   queryClient.setQueryDefaults(uploadQueue.online(), pollingConfig)
   queryClient.setQueryDefaults(uploadQueue.offline(), pollingConfig)
+  queryClient.setQueryDefaults(route.prefix, { ...dontRefetchOften, ...useSuspense })
 
   return queryClient
 }

--- a/src/api/query-client.ts
+++ b/src/api/query-client.ts
@@ -2,6 +2,7 @@ import { QueryClient } from '@tanstack/solid-query'
 import { queries as uploadQueue } from '~/components/UploadQueue'
 import { queries as routes } from '~/pages/dashboard/activities/RouteActivity'
 import { queries as devices } from '~/pages/dashboard/activities/DeviceActivity'
+import { queries as dashboard } from '~/pages/dashboard/Dashboard'
 
 const pollingConfig = { retry: false, refetchInterval: 1000 }
 
@@ -15,6 +16,7 @@ export const getAppQueryClient = () => {
   queryClient.setQueryDefaults(routes.location(), { refetchOnMount: false })
   queryClient.setQueryDefaults(devices.device, { refetchOnMount: false })
   queryClient.setQueryDefaults(devices.allDevices(), { refetchOnMount: false })
+  queryClient.setQueryDefaults(dashboard.profile, { refetchOnMount: false })
 
   return queryClient
 }

--- a/src/api/query-client.ts
+++ b/src/api/query-client.ts
@@ -2,20 +2,19 @@ import { QueryClient } from '@tanstack/solid-query'
 import { queries as uploadQueue } from '~/components/UploadQueue'
 import { queries as routes } from '~/pages/dashboard/activities/RouteActivity'
 
-const dontRefetchOften = {
-  staleTime: 1000 * 60 * 60, // 1 hour
+const refreshAfterMs = (refreshAfterMs: number) => ({
+  staleTime: refreshAfterMs,
   refetchOnMount: false,
   refetchOnWindowFocus: false,
-}
+})
 const pollingConfig = { retry: false, refetchInterval: 1000 }
-const useSuspense = { throwOnError: true }
 
 export const getAppQueryClient = () => {
   const queryClient = new QueryClient()
 
   queryClient.setQueryDefaults(uploadQueue.online(), pollingConfig)
   queryClient.setQueryDefaults(uploadQueue.offline(), pollingConfig)
-  queryClient.setQueryDefaults(routes.route(), { ...dontRefetchOften, ...useSuspense })
+  queryClient.setQueryDefaults(routes.route(), refreshAfterMs(1000 * 60 * 60)) // 1 hour
 
   return queryClient
 }

--- a/src/components/RouteActions.tsx
+++ b/src/components/RouteActions.tsx
@@ -91,6 +91,8 @@ const RouteActions: VoidComponent<RouteActionsProps> = (props) => {
         setError('Failed to update toggle')
       }
     }
+
+    // TODO: mutate route so status is preserved
   }
 
   const currentRouteId = () => props.routeName.replace('|', '/')

--- a/src/components/RouteStatisticsBar.tsx
+++ b/src/components/RouteStatisticsBar.tsx
@@ -1,4 +1,4 @@
-import type { Resource, VoidComponent } from 'solid-js'
+import type { VoidComponent } from 'solid-js'
 
 import type { RouteStatistics } from '~/api/derived'
 import type { Route } from '~/api/types'
@@ -11,7 +11,9 @@ const formatEngagement = (statistics: RouteStatistics | undefined): string | und
   return `${(100 * (engagedDurationMs / routeDurationMs)).toFixed(0)}%`
 }
 
-const RouteStatisticsBar: VoidComponent<{ class?: string; route: Route | undefined; statistics: Resource<RouteStatistics> }> = (props) => {
+const RouteStatisticsBar: VoidComponent<{ class?: string; route: Route | undefined; statistics: RouteStatistics | undefined }> = (
+  props,
+) => {
   return (
     <StatisticBar
       class={props.class}
@@ -20,11 +22,9 @@ const RouteStatisticsBar: VoidComponent<{ class?: string; route: Route | undefin
         {
           label: 'Duration',
           value: () =>
-            props.statistics.state === 'ready' || props.statistics.state === 'refreshing'
-              ? formatDuration(props.statistics().routeDurationMs / (60 * 1000))
-              : formatRouteDuration(props.route),
+            props.statistics ? formatDuration(props.statistics.routeDurationMs / (60 * 1000)) : formatRouteDuration(props.route),
         },
-        { label: 'Engaged', value: () => formatEngagement(props.statistics()) },
+        { label: 'Engaged', value: () => formatEngagement(props.statistics) },
       ]}
     />
   )

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -25,7 +25,7 @@ import { isSignedIn } from '~/api/auth/client'
 
 const PairActivity = lazy(() => import('./activities/PairActivity'))
 
-const queries = {
+export const queries = {
   profile: ['profile'],
   getProfile: () => queryOptions({ queryKey: queries.profile, queryFn: getProfile }),
 }
@@ -172,9 +172,6 @@ const Dashboard: Component<RouteSectionProps> = () => {
               paneTwoContent={!!urlState().dateStr}
             />
           )}
-        </Match>
-        <Match when={!profile.loading && !profile.latest}>
-          <Navigate href="/login" />
         </Match>
         <Match when={getDefaultDongleId()} keyed>
           {(defaultDongleId) => <Navigate href={`/${defaultDongleId}`} />}

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -36,12 +36,13 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
   const [videoRef, setVideoRef] = createSignal<HTMLVideoElement>()
 
   const routeName = () => `${props.dongleId}|${props.dateStr}`
-  const route = createQuery(() => queries.getRoute(routeName()))
-  const [startTime] = createResource(route, (route) => dayjs(route.data?.start_time)?.format('dddd, MMM D, YYYY'))
+  const routeQuery = createQuery(() => queries.getRoute(routeName()))
+  const route = () => routeQuery.data
+  const [startTime] = createResource(route, (route) => dayjs(route?.start_time)?.format('dddd, MMM D, YYYY'))
 
   const selection = () => ({ startTime: props.startTime, endTime: props.endTime })
 
-  const [statistics] = createResource(route.data, getRouteStatistics)
+  const [statistics] = createResource(route(), getRouteStatistics)
 
   const onTimelineChange = (newTime: number) => {
     const video = videoRef()
@@ -87,16 +88,16 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
         <div class="flex flex-col gap-2">
           <span class="text-label-md uppercase">Route Info</span>
           <div class="flex flex-col rounded-md overflow-hidden bg-surface-container">
-            <RouteStatisticsBar class="p-5" route={route.data} statistics={statistics} />
+            <RouteStatisticsBar class="p-5" route={route()} statistics={statistics} />
 
-            <RouteActions routeName={routeName()} route={route.data} />
+            <RouteActions routeName={routeName()} route={route()} />
           </div>
         </div>
 
         <div class="flex flex-col gap-2">
           <span class="text-label-md uppercase">Upload Files</span>
           <div class="flex flex-col rounded-md overflow-hidden bg-surface-container">
-            <RouteUploadButtons route={route.data} />
+            <RouteUploadButtons route={route()} />
           </div>
         </div>
 
@@ -104,7 +105,7 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
           <span class="text-label-md uppercase">Route Map</span>
           <div class="aspect-square overflow-hidden rounded-lg">
             <Suspense fallback={<div class="h-full w-full skeleton-loader bg-surface-container" />}>
-              <RouteStaticMap route={route.data} />
+              <RouteStaticMap route={route()} />
             </Suspense>
           </div>
         </div>

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -27,8 +27,8 @@ type RouteActivityProps = {
 
 export const queries = {
   prefix: ['route'],
-  route: () => queries.prefix,
-  forRouteName: (routeName: string) => [queries.route(), routeName],
+  route: () => [...queries.prefix],
+  forRouteName: (routeName: string) => [...queries.route(), routeName],
   getRoute: (routeName: string) => queryOptions({ queryKey: queries.forRouteName(routeName), queryFn: () => getRoute(routeName) }),
 }
 

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -83,7 +83,7 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
   })
 
   const device = createQuery(() => deviceQueries.getDevice(props.dongleId))
-  const profile = createQuery(() => dashboardQueries.getProfile())
+  const profile = createQuery(dashboardQueries.getProfile)
   createEffect(() => {
     if (device.data && profile.data) {
       if (!device.data.is_owner && !profile.data.superuser) return

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -26,9 +26,8 @@ type RouteActivityProps = {
 }
 
 export const queries = {
-  prefix: ['route'],
-  route: () => queries.prefix,
-  forRouteName: (routeName: string) => [...queries.route(), routeName],
+  route: ['route'],
+  forRouteName: (routeName: string) => [...queries.route, routeName],
   getRoute: (routeName: string) => queryOptions({ queryKey: queries.forRouteName(routeName), queryFn: () => getRoute(routeName) }),
 }
 

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -27,8 +27,8 @@ type RouteActivityProps = {
 
 export const queries = {
   route: ['route'],
-  forRouteName: (routeName: string) => [...queries.route, routeName],
-  getRoute: (routeName: string) => queryOptions({ queryKey: queries.forRouteName(routeName), queryFn: () => getRoute(routeName) }),
+  forRoute: (routeName: string) => [...queries.route, routeName],
+  getRoute: (routeName: string) => queryOptions({ queryKey: queries.forRoute(routeName), queryFn: () => getRoute(routeName) }),
 }
 
 const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -27,7 +27,7 @@ type RouteActivityProps = {
 
 export const queries = {
   prefix: ['route'],
-  route: () => [...queries.prefix],
+  route: () => queries.prefix,
   forRouteName: (routeName: string) => [...queries.route(), routeName],
   getRoute: (routeName: string) => queryOptions({ queryKey: queries.forRouteName(routeName), queryFn: () => getRoute(routeName) }),
 }

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -150,7 +150,7 @@ const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
                 {(route) => {
                   const firstHeader = prevDayHeader === null
                   const dayHeader = getDayHeader(route)
-                  queryClient.setQueryData(queries.forRouteName(route.fullname), route)
+                  queryClient.setQueryData(queries.forRoute(route.fullname), route)
                   return (
                     <>
                       <Show when={dayHeader}>

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -13,6 +13,8 @@ import RouteStatisticsBar from '~/components/RouteStatisticsBar'
 import { getPlaceName } from '~/map/geocode'
 import type { Route } from '~/api/types'
 import { dateTimeToColorBetween } from '~/utils/format'
+import { useQueryClient } from '@tanstack/solid-query'
+import { queries } from '../activities/RouteActivity'
 
 interface RouteCardProps {
   route: Route
@@ -79,6 +81,7 @@ const Sentinel = (props: { onTrigger: () => void }) => {
 const PAGE_SIZE = 10
 
 const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
+  const queryClient = useQueryClient()
   const endpoint = () => `/v1/devices/${props.dongleId}/routes?limit=${PAGE_SIZE}`
   const getKey = (previousPageData?: Route[]): string | undefined => {
     if (!previousPageData) return endpoint()
@@ -147,6 +150,7 @@ const RouteList: VoidComponent<{ dongleId: string }> = (props) => {
                 {(route) => {
                   const firstHeader = prevDayHeader === null
                   const dayHeader = getDayHeader(route)
+                  queryClient.setQueryData(queries.forRouteName(route.fullname), route)
                   return (
                     <>
                       <Show when={dayHeader}>

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -2,6 +2,7 @@ import { createEffect, createResource, createSignal, For, Index, onCleanup, onMo
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc.js'
 import timezone from 'dayjs/plugin/timezone.js'
+import { useQueryClient } from '@tanstack/solid-query'
 dayjs.extend(utc)
 dayjs.extend(timezone)
 
@@ -13,7 +14,6 @@ import RouteStatisticsBar from '~/components/RouteStatisticsBar'
 import { getPlaceName } from '~/map/geocode'
 import type { Route } from '~/api/types'
 import { dateTimeToColorBetween } from '~/utils/format'
-import { useQueryClient } from '@tanstack/solid-query'
 import { queries } from '../activities/RouteActivity'
 
 interface RouteCardProps {

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -12,9 +12,9 @@ import Card, { CardContent, CardHeader } from '~/components/material/Card'
 import Icon from '~/components/material/Icon'
 import RouteStatisticsBar from '~/components/RouteStatisticsBar'
 import { getPlaceName } from '~/map/geocode'
+import { queries } from '~/pages/dashboard/activities/RouteActivity'
 import type { Route } from '~/api/types'
 import { dateTimeToColorBetween } from '~/utils/format'
-import { queries } from '../activities/RouteActivity'
 
 interface RouteCardProps {
   route: Route

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -2,19 +2,17 @@ import { createEffect, createResource, createSignal, For, Index, onCleanup, onMo
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc.js'
 import timezone from 'dayjs/plugin/timezone.js'
-import { useQueryClient } from '@tanstack/solid-query'
+import { createQuery, useQueryClient } from '@tanstack/solid-query'
 dayjs.extend(utc)
 dayjs.extend(timezone)
 
-import { fetcher } from '~/api'
-import { getRouteStatistics } from '~/api/derived'
 import Card, { CardContent, CardHeader } from '~/components/material/Card'
 import Icon from '~/components/material/Icon'
 import RouteStatisticsBar from '~/components/RouteStatisticsBar'
-import { getPlaceName } from '~/map/geocode'
 import { queries } from '~/pages/dashboard/activities/RouteActivity'
 import type { Route } from '~/api/types'
 import { dateTimeToColorBetween } from '~/utils/format'
+import { fetcher } from '~/api'
 
 interface RouteCardProps {
   route: Route
@@ -24,17 +22,8 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   const startTime = () => dayjs.utc(props.route.start_time).local()
   const endTime = () => dayjs.utc(props.route.end_time).local()
   const color = () => dateTimeToColorBetween(startTime().toDate(), endTime().toDate(), [30, 57, 138], [218, 161, 28])
-  const [statistics] = createResource(() => props.route, getRouteStatistics)
-  const [location] = createResource(async () => {
-    const startPos = [props.route.start_lng || 0, props.route.start_lat || 0]
-    const endPos = [props.route.end_lng || 0, props.route.end_lat || 0]
-    const startPlace = await getPlaceName(startPos)
-    const endPlace = await getPlaceName(endPos)
-    if (!startPlace && !endPlace) return ''
-    if (!endPlace || startPlace === endPlace) return startPlace
-    if (!startPlace) return endPlace
-    return `${startPlace} to ${endPlace}`
-  })
+  const statistics = createQuery(() => queries.getRouteStatistics(props.route))
+  const location = createQuery(() => queries.getRouteLocation(props.route))
 
   return (
     <Card class="max-w-none" href={`/${props.route.dongle_id}/${props.route.fullname.slice(17)}`} activeClass="md:before:bg-primary">
@@ -44,10 +33,10 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
             {startTime().format('h:mm A')} to {endTime().format('h:mm A')}
           </span>
         }
-        subhead={<Suspense fallback={<div class="h-[20px] w-auto skeleton-loader rounded-xs" />}>{location()}</Suspense>}
+        subhead={<Suspense fallback={<div class="h-[20px] w-auto skeleton-loader rounded-xs" />}>{location.data}</Suspense>}
         trailing={
           <Suspense>
-            <Show when={statistics()?.userFlags}>
+            <Show when={statistics.data?.userFlags}>
               <div class="flex items-center justify-center rounded-full p-1 border-amber-300 border-2">
                 <Icon class="text-yellow-300" size="24" name="flag" filled />
               </div>
@@ -57,7 +46,7 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
       />
 
       <CardContent>
-        <RouteStatisticsBar route={props.route} statistics={statistics} />
+        <RouteStatisticsBar route={props.route} statistics={statistics.data!} />
       </CardContent>
       <div class="h-2.5 w-full" style={{ background: color() }} />
     </Card>


### PR DESCRIPTION
like https://github.com/commaai/connect/pull/514, but for every critical path network request

the only things that get fetched on-demand are:
1. map coordinates
2. qcam stream URL

(only fetched once, then cached for as long as the page is open)

everything else is loaded from Dashboard or RouteList initial load

not meant to merge as it needs lots of polish and can be done in less lines, this is for demo purposes only

https://github.com/user-attachments/assets/8c702221-39d1-4120-8c57-029b0eac59f3

notes:
1.  we could technically optimistically fetch more data ([see docs](https://tanstack.com/query/latest/docs/framework/solid/guides/prefetching)), but it might add too much up front network pressure

