### PR TITLE
fix(UploadQueue): hide 'cancel all' when online queue is empty

### DIFF
--- a/src/components/UploadQueue.tsx
+++ b/src/components/UploadQueue.tsx
@@ -118,9 +118,11 @@ const UploadQueue: VoidComponent<{ dongleId: string }> = (props) => {
     <div class="flex flex-col gap-4 bg-surface-container-lowest">
       <div class="flex p-4 justify-between items-center border-b-2 border-b-surface-container-low">
         <StatisticBar statistics={[{ label: 'Queued', value: () => items.length }]} />
-        <Button onClick={cancelAll} class="px-2 md:px-3" leading={<Icon name="close" size="20" />} color="primary">
-          <span class="flex items-center gap-1 font-mono">Cancel All</span>
-        </Button>
+        <Show when={onlineQueue.data?.result?.length}>
+          <Button onClick={cancelAll} class="px-2 md:px-3" leading={<Icon name="close" size="20" />} color="primary">
+            <span class="flex items-center gap-1 font-mono">Cancel All</span>
+          </Button>
+        </Show>
       </div>
       <div class="relative h-[calc(4*3rem)] sm:h-[calc(6*3rem)] flex justify-center items-center text-on-surface-variant">
         <Switch


### PR DESCRIPTION
Only show the "cancel all" button if the online queue is populated (this should mean the device is online too?)

closes #322