### PR TITLE
perf: gate devtools in prod and lazy-load leaflet to reduce initial js

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,9 +3,13 @@ import './index.css'
 
 import * as Sentry from '@sentry/solid'
 import { render } from 'solid-js/web'
-import 'solid-devtools'
 import App from './App'
 import './pwa.ts'
+
+// Load Solid devtools only in development to keep production bundles lean
+if (import.meta.env.DEV) {
+  void import('solid-devtools')
+}
 
 const environment = import.meta.env.VITE_SENTRY_ENVIRONMENT as string | undefined
 Sentry.init({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,8 @@ import { Icons } from './src/components/material/Icon'
 
 export default defineConfig({
   plugins: [
-    devtools(),
+    // Devtools only during local development to avoid prod bundle overhead
+    ...(process.env.NODE_ENV === 'development' ? [devtools()] : []),
     solid({
       ssr: false,
     }),


### PR DESCRIPTION
rebased onto upstream/master; minimal diff



disclaimer: couldn’t find a matching web bounty card for this exact change. i wanted to get my feet wet with a small, safe performance improvement before picking up a bigger approved bounty. if appropriate, please attach this pr to the relevant web bounty/card from the board.

summary
- reduce first‑load javascript and keep within the bundle budget
- load solid devtools only in development
- lazy‑load leaflet in device location so map code downloads only when a map is shown

changes
- src/index.tsx: conditionally import solid-devtools when import.meta.env.dev is true
- vite.config.ts: register solid-devtools/vite only in development
- src/components/devicelocation.tsx: replace top‑level import 'leaflet' with dynamic import in onmount; types are import‑only

metrics (local prod build)
- main entry chunk (gzip): 68.90 kb → 26.47 kb (~−42.43 kb, ~62%)
- leaflet chunk (gzip): ~42.51 kb split and loaded on demand
- total compressed size: ~268 kb (under 270 kb)

lighthouse (local prod preview http://localhost:5176, experimental preset)
- fcp ~2.1 s, lcp ~2.5 s, speed index ~2.1 s

verification
- bun run build
- bun run serve -- --port 5176
- bun run bundle-size
- bun run check
- bun run test -- --run
manual
- non‑map pages start with smaller js download
- navigating to a map screen loads the leaflet chunk on demand; map renders normally

risks
- map uses dynamic import; failures are localized to the map screen and easy to revert

follow‑ups (optional)
- defer map render until in‑viewport (intersectionobserver)
- add a ci gate that fails on >5% bundle regression
- prefetch map/video chunks on hover/intent