### PR TITLE
fix: gracefully handle routes missing start/end times

### DIFF
--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -31,8 +31,7 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
 
   const routeName = () => `${props.dongleId}|${props.dateStr}`
   const [route] = createResource(routeName, getRoute)
-  const startTime = () => (route.latest ? dayjs(route().start_time).format('dddd, MMM D, YYYY') : '')
-
+  const startTime = () => (route.latest?.start_time ? dayjs(route().start_time).format('dddd, MMM D, YYYY') : '')
   const selection = () => ({ startTime: props.startTime, endTime: props.endTime })
 
   // FIXME: generateTimelineStatistics is given different versions of TimelineEvents multiple times, leading to stuttering engaged % on switch

--- a/src/pages/dashboard/activities/RouteActivity.tsx
+++ b/src/pages/dashboard/activities/RouteActivity.tsx
@@ -31,7 +31,7 @@ const RouteActivity: VoidComponent<RouteActivityProps> = (props) => {
 
   const routeName = () => `${props.dongleId}|${props.dateStr}`
   const [route] = createResource(routeName, getRoute)
-  const startTime = () => (route.latest?.start_time ? dayjs(route().start_time).format('dddd, MMM D, YYYY') : '')
+  const startTime = () => (route.latest?.start_time ? dayjs(route().start_time).format('dddd, MMM D, YYYY') : props.dateStr)
   const selection = () => ({ startTime: props.startTime, endTime: props.endTime })
 
   // FIXME: generateTimelineStatistics is given different versions of TimelineEvents multiple times, leading to stuttering engaged % on switch

--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -36,12 +36,8 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   })
 
   const getCardHeadline = () => {
-    if (!startTime() || !endTime()) return <>{props.route.fullname.split('|')[1]}</>
-    return (
-      <>
-        {startTime()?.format('h:mm A')} to {endTime()?.format('h:mm A')}
-      </>
-    )
+    if (!startTime() || !endTime()) return props.route.fullname.split('|')[1]
+    return `${startTime()!.format('h:mm A')} to ${endTime()!.format('h:mm A')}`
   }
 
   return (


### PR DESCRIPTION
resolves: https://github.com/commaai/new-connect/issues/60

* card color is black if no start/end
* group routes missing start/end time with nearest date. they will be ordered by create date so it's as accurate as we can get given the data without making the UX clunkier (don't want to group them separately)
* use dateStr in route activity title if date is missing

<img width="1290" height="597" alt="image" src="https://github.com/user-attachments/assets/ef1ca186-babc-42fc-a1ef-aadf798a4b0f" />
