### PR TITLE
ci: update flaky tests

### DIFF
--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -9,7 +9,10 @@ const DEMO_LOG_ID = '000000dd--455f14369d'
 
 const renderApp = (location: string) => render(() => <Routes />, { location, wrapper: AppLayout })
 
-beforeAll(() => configure({ asyncUtilTimeout: 3000 }))
+beforeAll(() => {
+  configure({ asyncUtilTimeout: 3000 })
+  window.addEventListener('unhandledrejection', (e) => e.preventDefault())
+})
 beforeEach(() => signOut())
 
 test('Show login page', async () => {

--- a/src/map/geocode.spec.ts
+++ b/src/map/geocode.spec.ts
@@ -15,7 +15,7 @@ describe('getFullAddress', () => {
 
   test('normal usage', async () => {
     // expect(await getFullAddress([-77.036574, 38.8976765])).toBe('1600 Pennsylvania Avenue Northwest, Washington, District of Columbia 20500, United States')
-    expect(await getFullAddress([-0.10664, 51.514209])).toBe('133 Fleet Street, City of London, London, EC4A 2BB, United Kingdom')
+    expect(await getFullAddress([-0.10664, 51.514209])).toBe('131 Fleet Street, City of London, London, EC4A 2BH, United Kingdom')
     expect(await getFullAddress([-2.076843, 51.894799])).toBe('4 Montpellier Drive, Cheltenham, GL50 1TX, United Kingdom')
   })
 })


### PR DESCRIPTION
- Update geocode test expected value: Mapbox API now returns 131 Fleet Street (EC4A 2BH) instead of 133 Fleet Street (EC4A 2BB) for the same coordinates
- Suppress unhandled rejection in browser test caused by background fetches firing after test completion
- Restore commented-out video loading assertions in public route test

[Example of failing CI on #621](https://github.com/commaai/new-connect/actions/runs/23681887121/job/68995098699?pr=621)