### PR TITLE
fix: replace daylight bar with sun/moon icon

### DIFF
--- a/src/pages/dashboard/components/RouteList.tsx
+++ b/src/pages/dashboard/components/RouteList.tsx
@@ -22,6 +22,10 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
   const startTime = () => dayjs.utc(props.route.start_time).local()
   const endTime = () => dayjs.utc(props.route.end_time).local()
   const color = () => dateTimeToColorBetween(startTime().toDate(), endTime().toDate(), [30, 57, 138], [218, 161, 28])
+  const isDaytime = () => {
+    const hours = (startTime().hour() + startTime().minute() / 60 + endTime().hour() + endTime().minute() / 60) / 2
+    return hours > 5.5 && hours < 18.5
+  }
   const [statistics] = createResource(() => props.route, getRouteStatistics)
   const [location] = createResource(async () => {
     const startPos = [props.route.start_lng || 0, props.route.start_lat || 0]
@@ -53,7 +57,37 @@ const RouteCard: VoidComponent<RouteCardProps> = (props) => {
       <CardContent>
         <RouteStatisticsBar route={props.route} statistics={statistics} />
       </CardContent>
-      <div class="h-2.5 w-full" style={{ background: color() }} />
+
+      <div class="flex items-center justify-end px-3 py-1.5">
+        <Show
+          when={isDaytime()}
+          fallback={
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-5" style={{ color: color() }}>
+              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+            </svg>
+          }
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            class="size-5"
+            style={{ color: color() }}
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <circle cx="12" cy="12" r="5" />
+            <line x1="12" y1="1" x2="12" y2="3" />
+            <line x1="12" y1="21" x2="12" y2="23" />
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+            <line x1="1" y1="12" x2="3" y2="12" />
+            <line x1="21" y1="12" x2="23" y2="12" />
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+          </svg>
+        </Show>
+      </div>
     </Card>
   )
 }


### PR DESCRIPTION
Fixes #518

The daylight indicator bar was easily confused with the route 
timeline bar. This replaces it with a sun/moon icon that clearly 
communicates the time of day the drive happened.

- Shows ☀️ sun icon for daytime routes (5:30 AM - 6:30 PM)
- Shows 🌙 moon icon for night routes
- Icon color uses the same dateTimeToColorBetween logic as before