### PR TITLE
feat: redirect back to intended route after login

### DIFF
--- a/src/App.browser.test.tsx
+++ b/src/App.browser.test.tsx
@@ -4,6 +4,7 @@ import { configure, render, waitFor } from '@solidjs/testing-library'
 import { setAccessToken, signOut } from '~/api/auth/client'
 import * as Demo from '~/api/auth/demo'
 import { AppLayout, Routes } from './App'
+import { isSafeInternalPath, popRedirect } from '~/api/auth/redirect'
 
 const DEMO_LOG_ID = '000000dd--455f14369d'
 
@@ -30,6 +31,24 @@ describe('Demo mode', () => {
     expect(await findByText(DEMO_LOG_ID)).toBeTruthy()
     const video = (await findByTestId('route-video')) as HTMLVideoElement
     await waitFor(() => expect(video.src).toBeTruthy())
+  })
+})
+
+describe('Post-login redirect', () => {
+  test('open-redirect guard rejects external and malformed targets', () => {
+    expect(isSafeInternalPath('/abc123/route')).toBe(true)
+    expect(isSafeInternalPath('//evil.com')).toBe(false)
+    expect(isSafeInternalPath('/\\evil.com')).toBe(false)
+    expect(isSafeInternalPath('https://evil.com')).toBe(false)
+    expect(isSafeInternalPath('')).toBe(false)
+    expect(isSafeInternalPath(null)).toBe(false)
+  })
+
+  test('remembers intended destination when visiting a protected route signed out', async () => {
+    const dest = `/${Demo.DONGLE_ID}/${DEMO_LOG_ID}`
+    const { findByText } = renderApp(dest)
+    expect(await findByText('Sign in with Google')).toBeTruthy()
+    expect(popRedirect()).toBe(dest)
   })
 })
 

--- a/src/api/auth/redirect.ts
+++ b/src/api/auth/redirect.ts
@@ -1,0 +1,16 @@
+import storage from '~/utils/storage'
+
+export const isSafeInternalPath = (path: unknown): path is string =>
+  typeof path === 'string' && path.startsWith('/') && !path.startsWith('//') && !path.startsWith('/\\')
+
+export const saveRedirect = (path: string): void => {
+  if (isSafeInternalPath(path)) {
+    storage.setItem('postLoginRedirect', path)
+  }
+}
+
+export const popRedirect = (): string | null => {
+  const path = storage.getItem('postLoginRedirect')
+  storage.removeItem('postLoginRedirect')
+  return isSafeInternalPath(path) ? path : null
+}

--- a/src/pages/auth/auth.tsx
+++ b/src/pages/auth/auth.tsx
@@ -4,6 +4,7 @@ import { Navigate, useNavigate, useSearchParams } from '@solidjs/router'
 import { refreshAccessToken } from '~/api/auth/client'
 import Button from '~/components/material/Button'
 import Icon from '~/components/material/Icon'
+import { popRedirect } from '~/api/auth/redirect'
 
 type AuthParams = {
   code: string
@@ -18,7 +19,7 @@ export default function Auth() {
   const { code, provider } = params
   if (code && provider) {
     void refreshAccessToken(code, provider)
-      .then(() => navigate('/'))
+      .then(() => navigate(popRedirect() ?? '/'))
       .catch((err) => {
         console.error(err)
         if (err instanceof Error && err.message) {

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -22,6 +22,7 @@ import DeviceActivity from './activities/DeviceActivity'
 import RouteActivity from './activities/RouteActivity'
 import SettingsActivity from './activities/SettingsActivity'
 import BuildInfo from '~/components/BuildInfo'
+import { saveRedirect } from '~/api/auth/redirect'
 
 const PairActivity = lazy(() => import('./activities/PairActivity'))
 
@@ -127,6 +128,12 @@ const FirstPairActivity: Component = () => {
   )
 }
 
+const RedirectToLogin: VoidComponent = () => {
+  const location = useLocation()
+  saveRedirect(`${location.pathname}${location.search}`)
+  return <Navigate href="/login" />
+}
+
 const Dashboard: Component<RouteSectionProps> = () => {
   const location = useLocation()
   const urlState = createMemo(() => {
@@ -156,7 +163,7 @@ const Dashboard: Component<RouteSectionProps> = () => {
     <Drawer drawer={<DashboardDrawer devices={devices()} />}>
       <Switch>
         <Match when={!isSignedIn()}>
-          <Navigate href="/login" />
+          <RedirectToLogin />
         </Match>
         <Match when={urlState().dongleId === 'pair' || !!location.query.pair}>
           <PairActivity onPaired={refetch} />

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -6,7 +6,7 @@ const STORAGE_PREFIX = 'connect:'
 /**
  * Storage key type. Used to catch typos in the key name.
  */
-type StorageKey = 'lastSelectedDongleId'
+type StorageKey = 'lastSelectedDongleId' | 'postLoginRedirect'
 
 export default {
   getItem(key: StorageKey): string | null {
@@ -15,5 +15,9 @@ export default {
 
   setItem(key: StorageKey, value: string): void {
     localStorage.setItem(STORAGE_PREFIX + key, value)
+  },
+
+  removeItem(key: StorageKey): void {
+    localStorage.removeItem(STORAGE_PREFIX + key)
   },
 }


### PR DESCRIPTION
Closes #523

## What
Signed-out users who open a deep link (like a shared route) get sent to /login, but after logging in they always landed on / instead of where they were going. This sends them back to the original route.

## How
- New `src/api/auth/redirect.ts` with `saveRedirect()`, `popRedirect()` (read + clear), and `isSafeInternalPath()`.
- `Dashboard.tsx`: save the current path before redirecting to /login when not signed in.
- `auth.tsx`: changed `navigate('/')` to `navigate(popRedirect() ?? '/')` after the token exchange.
- `storage.ts`: added the `postLoginRedirect` key to the key union and a `removeItem` helper.

## Why not the OAuth state param
The issue links the Auth0 state-param doc. I looked at using it, but the redirect_uri for all 3 providers points at the comma API (`/v2/auth/{g,a,h}/redirect/`), which then redirects to `/auth?code=&provider=`. So the destination goes through the comma backend, not straight back from the provider, and I don't think a state value survives that unless the backend forwards it. Is that something the backend does?

For now I store the destination client-side, which works regardless. `popRedirect()` only allows internal paths (rejects `//host`, `/\host`, and absolute URLs) so a malicious login link can't redirect someone off-site after they log in. It's cleared on read so an old destination can't carry over to a later login.

Happy to switch to state if the backend supports it.

## Testing
Added a unit test for the path guard and an integration test that checks the destination is saved when you hit a protected route signed out.

Couldn't run the browser tests locally (I'm on Ubuntu 26.04 and the pinned Playwright doesn't support it yet), so I ran check/build/lines/bundle-size locally and left the browser tests to CI. Bundle goes up ~0.46KB gzipped.